### PR TITLE
fix(ci): avoid staged deletion of files

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -216,6 +216,7 @@ jobs:
           echo "Create the latest repository..."
           git clone --depth 1 --no-single-branch --no-checkout --branch main file://${PWD}/${{ inputs.tag }}.tmp ${{ inputs.tag }}
           rm -rf ${{ inputs.tag }}.tmp
+          git -C ${{ inputs.tag }} reset
           tar --warning=no-file-removed --remove-files -acf ${{ inputs.tag }}.tar.zst ${{ inputs.tag }}
 
       - name: Login to GitHub Packages Container registry

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -125,6 +125,7 @@ jobs:
 
           echo "Create the trucated repository..."
           git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main file://${PWD}/${{ inputs.tag }}.full ${{ inputs.tag }}
+          git -C ${{ inputs.tag }} reset
           git -C ${{ inputs.tag }} branch nightly origin/nightly
 
           rm -rf ${{ inputs.tag }}.full


### PR DESCRIPTION
Bug description

After archive and truncate, pulling dotgit and restore does not work as expected.
The cause is that "git clone --no-checkout" leaves the deletions in index (staged area) instead of working tree.

Demonstoration:
```
## Prepare origin
% mkdir test
% cd test
% git init && for i in {1..3}; do echo $i > test-$i.txt; git add . ; git commit -m $i; done
Initialized empty Git repository in /home/shino/sb/epss-investigate/test/.git/
[main (root-commit) 1bc5d1d] 1
 1 file changed, 1 insertion(+)
 create mode 100644 test-1.txt
[main 896e6ff] 2
 1 file changed, 1 insertion(+)
 create mode 100644 test-2.txt
[main 4f93950] 3
 1 file changed, 1 insertion(+)
 create mode 100644 test-3.txt
% cd ..

## Clone it with --no-checkout
% git clone --no-checkout file://$PWD/test test2
Cloning into 'test2'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 9 (delta 2), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (9/9), done.
Resolving deltas: 100% (2/2), done.

## Show index and working tree diffs
% cd test2
% git status
On branch main
Your branch is up to date with 'origin/main'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        deleted:    test-1.txt
        deleted:    test-2.txt
        deleted:    test-3.txt

% git diff
% git diff --staged
diff --git a/test-1.txt b/test-1.txt
deleted file mode 100644
index d00491f..0000000
--- a/test-1.txt
+++ /dev/null
@@ -1 +0,0 @@
-1
diff --git a/test-2.txt b/test-2.txt
deleted file mode 100644
index 0cfbf08..0000000
--- a/test-2.txt
+++ /dev/null
@@ -1 +0,0 @@
-2
diff --git a/test-3.txt b/test-3.txt
deleted file mode 100644
index 00750ed..0000000
--- a/test-3.txt
+++ /dev/null
@@ -1 +0,0 @@
-3
```

Expected state of dotgit is
- only .git/ directory exists and
- every file in working tree is in deleted state and
- no diff in index (staged area)

To realize this expections, we need "git reset" after clone:
```
% git reset
Unstaged changes after reset:
D       test-1.txt
D       test-2.txt
D       test-3.txt
% git diff --staged
% git diff
diff --git a/test-1.txt b/test-1.txt
deleted file mode 100644
index d00491f..0000000
--- a/test-1.txt
+++ /dev/null
@@ -1 +0,0 @@
-1
diff --git a/test-2.txt b/test-2.txt
deleted file mode 100644
index 0cfbf08..0000000
--- a/test-2.txt
+++ /dev/null
@@ -1 +0,0 @@
-2
diff --git a/test-3.txt b/test-3.txt
deleted file mode 100644
index 00750ed..0000000
--- a/test-3.txt
+++ /dev/null
@@ -1 +0,0 @@
-3
```

-------------

Confirmation of archive:
- pull raw alma-errata and change the name to vuls-data-raw-sample
- push it
- run archive.yml to the tag 
  - `gh workflow run archive.yml --ref shino/fix-git-clone -f tag=vuls-data-raw-sample -f threshold-mb=10`
- pull the archived and latest images

before archive:
```
% git diff --shortstat
 2256 files changed, 1079267 deletions(-)

% git log --oneline | wc -l
261

% git log --oneline | head -3
3d9be79b0 update
54c1e58ba update
9261fd610 update

% git diff --staged
(empty output)

% git diff --shortstat
 2256 files changed, 1079267 deletions(-)
```

after archive, archived one:
```
% git log --oneline| wc -l
261

% git log --oneline| head -3
3d9be79b0 update
54c1e58ba update
9261fd610 update

% git diff --staged
(empty output)

% git diff --shortstat
 2256 files changed, 1079267 deletions(-)
```

after archive, latest one:
```
% git log --oneline| wc -l
1

% git log --oneline
3d9be79 (grafted, HEAD -> main, origin/main, origin/HEAD) update

% git diff --staged
(empty output)

% git diff --shortstat
 2256 files changed, 1079267 deletions(-)
```

-------------

Confirmation of truncate:

- pull extracted alma-errata and change the name to vuls-data-extracted-sample
- push it
- run truncate.yml to the tag 
  - `gh workflow run truncate.yml --ref shino/fix-git-clone -f tag=vuls-data-extracted-sample -f threshold-mb=10 -f log-ratio=0.8`
- pull the truncated image

before truncate:
```
% git log main --oneline | wc -l
1282
% git log main --oneline | head -3
98505f094c update
229c42f0bd update
1496c0192e update

% git log nightly --oneline | wc -l
1281
% git log nightly --oneline | head -3
7623736e83 update
b54e6ca496 update
a246142480 update

% git diff --staged
(empty output)

% git diff --shortstat
 2244 files changed, 1228717 deletions(-)
```

after truncate:
```
% git branch
* main
  nightly

% git log main --oneline | wc -l
1026
% git log main --oneline | head -3
98505f094c update
229c42f0bd update
1496c0192e update

% git log nightly --oneline | wc -l
1025
% git log nightly --oneline | head -3
7623736e83 update
b54e6ca496 update
a246142480 update

% git diff --staged
(empty output)

% git diff --shortstat
 2244 files changed, 1228717 deletions(-)

% git s nightly --quiet

% git diff --staged
(empty output)

% git diff --shortstat
 2244 files changed, 1228717 deletions(-)
```

