### PR TITLE
fix(ci): treat tar exit status 0 and 1 as success

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -217,7 +217,7 @@ jobs:
           git clone --depth 1 --no-single-branch --no-checkout --branch main file://${PWD}/${{ inputs.tag }}.tmp ${{ inputs.tag }}
           rm -rf ${{ inputs.tag }}.tmp
           git -C ${{ inputs.tag }} reset
-          tar --warning=no-file-removed --remove-files -acf ${{ inputs.tag }}.tar.zst ${{ inputs.tag }}
+          tar --remove-files -acf ${{ inputs.tag }}.tar.zst ${{ inputs.tag }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -81,7 +81,7 @@ jobs:
           mv vuls-data-extracted-eol vuls-data-extracted-eol.tmp
           mkdir vuls-data-extracted-eol
           mv vuls-data-extracted-eol.tmp/.git vuls-data-extracted-eol
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-eol.tar.zst vuls-data-extracted-eol
+          tar --remove-files -acf vuls-data-extracted-eol.tar.zst vuls-data-extracted-eol || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -201,7 +201,7 @@ jobs:
           mv vuls-data-extracted-${{ inputs.target }} vuls-data-extracted-${{ inputs.target }}.tmp
           mkdir vuls-data-extracted-${{ inputs.target }}
           mv vuls-data-extracted-${{ inputs.target }}.tmp/.git vuls-data-extracted-${{ inputs.target }}
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-${{ inputs.target }}.tar.zst vuls-data-extracted-${{ inputs.target }}
+          tar --remove-files -acf vuls-data-extracted-${{ inputs.target }}.tar.zst vuls-data-extracted-${{ inputs.target }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -95,7 +95,7 @@ jobs:
           mv vuls-data-extracted-nvd-api-cve vuls-data-extracted-nvd-api-cve.tmp
           mkdir vuls-data-extracted-nvd-api-cve
           mv vuls-data-extracted-nvd-api-cve.tmp/.git vuls-data-extracted-nvd-api-cve
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-nvd-api-cve.tar.zst vuls-data-extracted-nvd-api-cve
+          tar --remove-files -acf vuls-data-extracted-nvd-api-cve.tar.zst vuls-data-extracted-nvd-api-cve || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -95,7 +95,7 @@ jobs:
           mv vuls-data-extracted-${{ inputs.target }}-rhel vuls-data-extracted-${{ inputs.target }}-rhel.tmp
           mkdir vuls-data-extracted-${{ inputs.target }}-rhel
           mv vuls-data-extracted-${{ inputs.target }}-rhel.tmp/.git vuls-data-extracted-${{ inputs.target }}-rhel
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-${{ inputs.target }}-rhel.tar.zst vuls-data-extracted-${{ inputs.target }}-rhel
+          tar --remove-files -acf vuls-data-extracted-${{ inputs.target }}-rhel.tar.zst vuls-data-extracted-${{ inputs.target }}-rhel || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-redhat-rhel-ovalv1.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv1.yml
@@ -99,7 +99,7 @@ jobs:
           mv vuls-data-extracted-redhat-ovalv1-rhel vuls-data-extracted-redhat-ovalv1-rhel.tmp
           mkdir vuls-data-extracted-redhat-ovalv1-rhel
           mv vuls-data-extracted-redhat-ovalv1-rhel.tmp/.git vuls-data-extracted-redhat-ovalv1-rhel
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-redhat-ovalv1-rhel.tar.zst vuls-data-extracted-redhat-ovalv1-rhel
+          tar --remove-files -acf vuls-data-extracted-redhat-ovalv1-rhel.tar.zst vuls-data-extracted-redhat-ovalv1-rhel || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-redhat-rhel-ovalv2.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv2.yml
@@ -107,7 +107,7 @@ jobs:
           mv vuls-data-extracted-redhat-ovalv2-rhel vuls-data-extracted-redhat-ovalv2-rhel.tmp
           mkdir vuls-data-extracted-redhat-ovalv2-rhel
           mv vuls-data-extracted-redhat-ovalv2-rhel.tmp/.git vuls-data-extracted-redhat-ovalv2-rhel
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-redhat-ovalv2-rhel.tar.zst vuls-data-extracted-redhat-ovalv2-rhel
+          tar --remove-files -acf vuls-data-extracted-redhat-ovalv2-rhel.tar.zst vuls-data-extracted-redhat-ovalv2-rhel || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -106,7 +106,7 @@ jobs:
           mv vuls-data-extracted-${{ inputs.target }} vuls-data-extracted-${{ inputs.target }}.tmp
           mkdir vuls-data-extracted-${{ inputs.target }}
           mv vuls-data-extracted-${{ inputs.target }}.tmp/.git vuls-data-extracted-${{ inputs.target }}
-          tar --warning=no-file-removed --remove-files -acf vuls-data-extracted-${{ inputs.target }}.tar.zst vuls-data-extracted-${{ inputs.target }}
+          tar --remove-files -acf vuls-data-extracted-${{ inputs.target }}.tar.zst vuls-data-extracted-${{ inputs.target }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -76,7 +76,7 @@ jobs:
           mv vuls-data-raw-epss vuls-data-raw-epss.tmp
           mkdir vuls-data-raw-epss
           mv vuls-data-raw-epss.tmp/.git vuls-data-raw-epss
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-epss.tar.zst vuls-data-raw-epss
+          tar --remove-files -acf vuls-data-raw-epss.tar.zst vuls-data-raw-epss || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-fedora.yml
+++ b/.github/workflows/fetch-fedora.yml
@@ -68,7 +68,7 @@ jobs:
           vuls-data-update fetch fedora --dir vuls-data-raw-fedora ${{ matrix.release }} --retry 10
 
       - name: Create tarball
-        run: tar --warning=no-file-removed --remove-files -acf vuls-data-raw-fedora.tar.zst vuls-data-raw-fedora
+        run: tar --remove-files -acf vuls-data-raw-fedora.tar.zst vuls-data-raw-fedora || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3
@@ -138,7 +138,7 @@ jobs:
           mv vuls-data-raw-fedora vuls-data-raw-fedora.tmp
           mkdir vuls-data-raw-fedora
           mv vuls-data-raw-fedora.tmp/.git vuls-data-raw-fedora
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-fedora.tar.zst vuls-data-raw-fedora
+          tar --remove-files -acf vuls-data-raw-fedora.tar.zst vuls-data-raw-fedora || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -77,7 +77,7 @@ jobs:
           mv vuls-data-raw-fortinet-cvrf vuls-data-raw-fortinet-cvrf.tmp
           mkdir vuls-data-raw-fortinet-cvrf
           mv vuls-data-raw-fortinet-cvrf.tmp/.git vuls-data-raw-fortinet-cvrf
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-fortinet-cvrf.tar.zst vuls-data-raw-fortinet-cvrf
+          tar --remove-files -acf vuls-data-raw-fortinet-cvrf.tar.zst vuls-data-raw-fortinet-cvrf || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -186,7 +186,7 @@ jobs:
           mv vuls-data-raw-${{ inputs.target }} vuls-data-raw-${{ inputs.target }}.tmp
           mkdir vuls-data-raw-${{ inputs.target }}
           mv vuls-data-raw-${{ inputs.target }}.tmp/.git vuls-data-raw-${{ inputs.target }}
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-${{ inputs.target }}.tar.zst vuls-data-raw-${{ inputs.target }}
+          tar --remove-files -acf vuls-data-raw-${{ inputs.target }}.tar.zst vuls-data-raw-${{ inputs.target }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -89,7 +89,7 @@ jobs:
           vuls-data-update fetch windows-msuc --dir vuls-data-raw-windows-msuc ${{ matrix.target }}
 
       - name: Create tarball
-        run: tar --warning=no-file-removed --remove-files -acf vuls-data-raw-windows-msuc.tar.zst vuls-data-raw-windows-msuc
+        run: tar --remove-files -acf vuls-data-raw-windows-msuc.tar.zst vuls-data-raw-windows-msuc || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3
@@ -161,7 +161,7 @@ jobs:
           mv vuls-data-raw-windows-msuc vuls-data-raw-windows-msuc.tmp
           mkdir vuls-data-raw-windows-msuc
           mv vuls-data-raw-windows-msuc.tmp/.git vuls-data-raw-windows-msuc
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-windows-msuc.tar.zst vuls-data-raw-windows-msuc
+          tar --remove-files -acf vuls-data-raw-windows-msuc.tar.zst vuls-data-raw-windows-msuc || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -94,7 +94,7 @@ jobs:
           mv vuls-data-raw-${{ inputs.target }} vuls-data-raw-${{ inputs.target }}.tmp
           mkdir vuls-data-raw-${{ inputs.target }}
           mv vuls-data-raw-${{ inputs.target }}.tmp/.git vuls-data-raw-${{ inputs.target }}
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-${{ inputs.target }}.tar.zst vuls-data-raw-${{ inputs.target }}
+          tar --remove-files -acf vuls-data-raw-${{ inputs.target }}.tar.zst vuls-data-raw-${{ inputs.target }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -82,7 +82,7 @@ jobs:
           mv vuls-data-raw-${{ inputs.target }} vuls-data-raw-${{ inputs.target }}.tmp
           mkdir vuls-data-raw-${{ inputs.target }}
           mv vuls-data-raw-${{ inputs.target }}.tmp/.git vuls-data-raw-${{ inputs.target }}
-          tar --warning=no-file-removed --remove-files -acf vuls-data-raw-${{ inputs.target }}.tar.zst vuls-data-raw-${{ inputs.target }}
+          tar --remove-files -acf vuls-data-raw-${{ inputs.target }}.tar.zst vuls-data-raw-${{ inputs.target }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -236,7 +236,7 @@ jobs:
           mv ${{ steps.pull.outputs.basename }} ${{ steps.pull.outputs.basename }}.tmp
           mkdir ${{ steps.pull.outputs.basename }}
           mv ${{ steps.pull.outputs.basename }}.tmp/.git ${{ steps.pull.outputs.basename }}
-          tar --warning=no-file-removed --remove-files -acf ${{ steps.pull.outputs.basename }}.tar.zst ${{ steps.pull.outputs.basename }}
+          tar --remove-files -acf ${{ steps.pull.outputs.basename }}.tar.zst ${{ steps.pull.outputs.basename }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir ${{ inputs.target }}
           mv .git ${{ inputs.target }}
-          tar --warning=no-file-removed --remove-files -acf ${{ inputs.target }}.tar.zst ${{ inputs.target }}
+          tar --remove-files -acf ${{ inputs.target }}.tar.zst ${{ inputs.target }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -129,7 +129,7 @@ jobs:
           git -C ${{ inputs.tag }} branch nightly origin/nightly
 
           rm -rf ${{ inputs.tag }}.full
-          tar --warning=no-file-removed --remove-files -acf ${{ inputs.tag }}.tar.zst ${{ inputs.tag }}
+          tar --remove-files -acf ${{ inputs.tag }}.tar.zst ${{ inputs.tag }} || [[ $? == 1 ]]
 
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
`--warning=no-file-removed` only suppresses the warning output and does not affect the exit status.
https://github.com/vulsio/vuls-data-db/actions/runs/13834718435/job/38706922197#step:12:8

Therefore, when the exit status is 1, we want to treat it as a success.

```
Possible exit codes of GNU tar are summarized in the following table:

0

    ‘Successful termination’.
1

    ‘Some files differ’. If tar was invoked with ‘--compare’ (‘--diff’, ‘-d’) command line option, this means that some files in the archive differ from their disk counterparts (see section [Comparing Archive Members with the File System](https://www.gnu.org/software/tar/manual/html_section/Advanced-tar.html#compare)). If tar was given ‘--create’, ‘--append’ or ‘--update’ option, this exit code means that some files were changed while being archived and so the resulting archive does not contain the exact copy of the file set.
2

    ‘Fatal error’. This means that some fatal, unrecoverable error occurred. 

If tar has invoked a subprocess and that subprocess exited with a nonzero exit code, tar exits with that code as well. This can happen, for example, if tar was given some compression option (see section [Creating and Reading Compressed Archives](https://www.gnu.org/software/tar/manual/html_section/Compression.html#gzip)) and the external compressor program failed. Another example is rmt failure during backup to the remote device (see section [Remote Tape Server](https://www.gnu.org/software/tar/manual/html_section/Remote-Tape-Server.html#Remote-Tape-Server)).
```
https://www.gnu.org/software/tar/manual/html_section/Synopsis.html