### PR TITLE
fix(ci): run even if other jobs fail

### DIFF
--- a/.github/workflows/archive-raw.yml
+++ b/.github/workflows/archive-raw.yml
@@ -147,6 +147,6 @@ jobs:
           fi
 
   archive-epss:
-    if: ${{ needs.check-archive-epss.outputs.do_archive == 'true' }}
+    if: ${{ ( success() || failure() ) && needs.check-archive-epss.outputs.do_archive == 'true' }}
     needs: [check-archive-epss]
     uses: ./.github/workflows/archive-epss.yml

--- a/.github/workflows/extract-all.yml
+++ b/.github/workflows/extract-all.yml
@@ -403,5 +403,5 @@ jobs:
   gc:
     name: Git GC Extracted
     needs: check
-    if: ${{ needs.check.outputs.do_gc == 'true' }}
+    if: ${{ ( success() || failure() ) && needs.check.outputs.do_gc == 'true' }}
     uses: ./.github/workflows/gc-extracted.yml

--- a/.github/workflows/fetch-all.yml
+++ b/.github/workflows/fetch-all.yml
@@ -225,5 +225,5 @@ jobs:
   gc:
     name: Git GC Raw
     needs: check
-    if: ${{ needs.check.outputs.do_gc == 'true' }}
+    if: ${{ ( success() || failure() ) && needs.check.outputs.do_gc == 'true' }}
     uses: ./.github/workflows/gc-raw.yml


### PR DESCRIPTION
The run_number was 50, and gc was expected to be performed, but it was not actually performed. The reason for this is thought to be that the if clause of the gc job did not take into account the case where other jobs fail.
https://github.com/vulsio/vuls-data-db/actions/runs/14162131881/job/39671296287
