### PR TITLE
fix(ci/db): checkout the specified branch

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -16,7 +16,9 @@ db-build:
 
 .PHONY: db-add
 db-add: 
-	vuls-data-update dotgit pull --dir . --restore ghcr.io/vulsio/vuls-data-db:${REPO}
+	vuls-data-update dotgit pull --dir . ghcr.io/vulsio/vuls-data-db:${REPO}
+	git -C ghcr.io/vulsio/vuls-data-db/${REPO} switch ${BRANCH}
+	git -C ghcr.io/vulsio/vuls-data-db/${REPO} restore .
 
 	cat ghcr.io/vulsio/vuls-data-db/${REPO}/datasource.json | jq --arg hash $$(git -C ghcr.io/vulsio/vuls-data-db/${REPO} rev-parse HEAD) --arg date $$(git -C ghcr.io/vulsio/vuls-data-db/${REPO} show -s --format=%at | xargs -I{} date -d @{} --utc +%Y-%m-%dT%TZ) '.extracted.commit |= $$hash | .extracted.date |= $$date' > tmp
 	mv tmp ghcr.io/vulsio/vuls-data-db/${REPO}/datasource.json

--- a/db-nightly.mk
+++ b/db-nightly.mk
@@ -16,7 +16,9 @@ db-build:
 
 .PHONY: db-add
 db-add: 
-	vuls-data-update dotgit pull --dir . --restore ghcr.io/vulsio/vuls-data-db:${REPO}
+	vuls-data-update dotgit pull --dir . ghcr.io/vulsio/vuls-data-db:${REPO}
+	git -C ghcr.io/vulsio/vuls-data-db/${REPO} switch ${BRANCH}
+	git -C ghcr.io/vulsio/vuls-data-db/${REPO} restore .
 
 	cat ghcr.io/vulsio/vuls-data-db/${REPO}/datasource.json | jq --arg hash $$(git -C ghcr.io/vulsio/vuls-data-db/${REPO} rev-parse HEAD) --arg date $$(git -C ghcr.io/vulsio/vuls-data-db/${REPO} show -s --format=%at | xargs -I{} date -d @{} --utc +%Y-%m-%dT%TZ) '.extracted.commit |= $$hash | .extracted.date |= $$date' > tmp
 	mv tmp ghcr.io/vulsio/vuls-data-db/${REPO}/datasource.json


### PR DESCRIPTION
Due to the change in #61, the branch of the extracted repository was always fixed to nightly. This PR fixes this so that the appropriate branch is checked out.