### PR TITLE
fix(ci/fetch-fedora): use single quote

### DIFF
--- a/.github/workflows/fetch-fedora.yml
+++ b/.github/workflows/fetch-fedora.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Aggregate fedora-data-*
         run: |
-          for release in $(echo "${{ needs.fedora-release.outputs.release }}" | jq -r '.[]'); do
+          for release in $(echo '${{ needs.fedora-release.outputs.release }}' | jq -r '.[]'); do
             vuls-data-update dotgit pull --dir . --checkout "" ghcr.io/${{ github.repository }}:fedora-data-${release}
             if ls ghcr.io/${{ github.repository }}/fedora-data-${release}/* >/dev/null 2>&1; then
               mv ghcr.io/${{ github.repository }}/fedora-data-${release}/* ghcr.io/${{ github.repository }}/vuls-data-raw-fedora/ 


### PR DESCRIPTION

https://github.com/vulsio/vuls-data-db/actions/runs/19316595857/job/55253671716

## before
```console
$ for release in $(echo "["EL-5","EL-6","ELN","EPEL-10.0","EPEL-10.1","EPEL-10.2","EPEL-7","EPEL-8","EPEL-8M","EPEL-8N","EPEL-9","EPEL-9N","F21","F22","F23","F24","F25","F26","F27","F27M","F28","F28C","F28M","F29","F29C","F29F","F29M","F30","F30C","F30F","F30M","F31","F31C","F31F","F31M","F32","F32C","F32F","F32M","F33","F33C","F33F","F33M","F34","F34C","F34F","F34M","F35","F35C","F35F","F35M","F36","F36C","F36F","F36M","F37","F37C","F37F","F37M","F38","F38C","F38F","F38M","F39","F39C","F39F","F40","F40C","F40F","F41","F41C","F41F","F42","F42C","F42F","F43","F43C","F43F","F44","F44F"]" | jq -r '.[]'); do
    echo "ghcr.io/vulsio/vuls-data-db:fedora-data-${release}"
  done
parse error: Invalid numeric literal at line 1, column 6

$ echo $?
0
```

## after
```console
$ for release in $(echo '["EL-5","EL-6","ELN","EPEL-10.0","EPEL-10.1","EPEL-10.2","EPEL-7","EPEL-8","EPEL-8M","EPEL-8N","EPEL-9","EPEL-9N","F21","F22","F23","F24","F25","F26","F27","F27M","F28","F28C","F28M","F29","F29C","F29F","F29M","F30","F30C","F30F","F30M","F31","F31C","F31F","F31M","F32","F32C","F32F","F32M","F33","F33C","F33F","F33M","F34","F34C","F34F","F34M","F35","F35C","F35F","F35M","F36","F36C","F36F","F36M","F37","F37C","F37F","F37M","F38","F38C","F38F","F38M","F39","F39C","F39F","F40","F40C","F40F","F41","F41C","F41F","F42","F42C","F42F","F43","F43C","F43F","F44","F44F"]' | jq -r '.[]'); do
    echo "ghcr.io/vulsio/vuls-data-db:fedora-data-${release}"
  done
ghcr.io/vulsio/vuls-data-db:fedora-data-EL-5
ghcr.io/vulsio/vuls-data-db:fedora-data-EL-6
ghcr.io/vulsio/vuls-data-db:fedora-data-ELN
...
```