### PR TITLE
fix(ci/cisco): fix field name changed in json/v2 adoption

### DIFF
--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -54,7 +54,7 @@ jobs:
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 
       - name: Fetch
-        run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} $(find ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json/ -name "*.json" | xargs jq -r --arg target ${{ inputs.target }} 'select(($target == "cisco-cvrf" and .cvrfUrl != "NA") or ($target == "cisco-csaf" and .csafUrl != "NA")) | .advisoryID' | tr '\n' ' ')
+        run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} $(find ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json/ -name "*.json" | xargs jq -r --arg target ${{ inputs.target }} 'select(($target == "cisco-cvrf" and .cvrfUrl != "NA") or ($target == "cisco-csaf" and .csafUrl != "NA")) | .advisoryId' | tr '\n' ' ')
 
       - name: Set Git config
         run: |


### PR DESCRIPTION
Errors:
- https://github.com/vulsio/vuls-data-db/actions/runs/20083351362/job/57615523582#step:8:5136
- https://github.com/vulsio/vuls-data-db/actions/runs/20083351362/job/57615523583#step:8:6492

Errors started around: https://github.com/vulsio/vuls-data-db/actions/runs/19750846646/job/56593579284#step:8:7170
at "Fri, 28 Nov 2025 01:17:33 GMT"

Commit logs of vuls-data-raw-cisco-json around the time:
```
* 737a5a3f      [2025-11-29 12:16:40 +0000] update GitHub Action
* b99835f3      [2025-11-29 00:46:14 +0000] update GitHub Action
* 6c0be927      [2025-11-28 12:20:02 +0000] update GitHub Action
* e5e7f2b2      [2025-11-28 00:43:22 +0000] update GitHub Action
* f895ffb0      [2025-11-27 12:19:20 +0000] update GitHub Action
* db2574e1      [2025-11-27 00:44:25 +0000] update GitHub Action
```

And the diff of the commit e5e7f2b2: 
```
commit e5e7f2b2cfe1fefd8e061284b3ffb0ac72b0a127
Author: GitHub Action <action@github.com>
Date:   Fri Nov 28 00:43:22 2025 +0000

    update

    GitHub Actions: https://github.com/vulsio/vuls-data-db/actions/runs/19750846646/job/56593496246

diff --git a/1995/cisco-sa-19950601-key-packet-bypass.json b/1995/cisco-sa-19950601-key-packet-bypass.json
index e41072d0..d9c5bce3 100644
--- a/1995/cisco-sa-19950601-key-packet-bypass.json
+++ b/1995/cisco-sa-19950601-key-packet-bypass.json
@@ -1,14 +1,14 @@
 {
-       "advisoryID": "cisco-sa-19950601-key-packet-bypass",
+       "advisoryId": "cisco-sa-19950601-key-packet-bypass",
        "advisoryTitle": "\"Established\" Keyword May Allow Packets to Bypass Filter",
        "bugIDs": [
                "NA"
        ],
-       "csafURL": "NA",
+       "csafUrl": "NA",
        "cves": [
                "NA"
        ],
[snip]
```

This bug was introduced by json/v2 adoption https://github.com/MaineK00n/vuls-data-update/pull/620

Case change is required.