### PR TITLE
fix(ci/git): disable git gc auto before dotgit compress

### DIFF
--- a/.github/workflows/archive-epss.yml
+++ b/.github/workflows/archive-epss.yml
@@ -40,6 +40,7 @@ jobs:
             mkdir vuls-data-raw-epss/
             mv ${y} vuls-data-raw-epss
             git -C vuls-data-raw-epss -c init.defaultBranch=main init .
+            git -C vuls-data-raw-epss config gc.auto 0
             git -C vuls-data-raw-epss config user.email "action@github.com"
             git -C vuls-data-raw-epss config user.name "GitHub Action"
             git -C vuls-data-raw-epss add ${y}
@@ -48,7 +49,7 @@ jobs:
             vuls-data-update dotgit compress vuls-data-raw-epss
             vuls-data-update dotgit registry push --force --token ${{ secrets.GITHUB_TOKEN }} ghcr.io/vulsio/vuls-data-db-archive:vuls-data-raw-epss-archive-$(( ${y} - 2020 )) vuls-data-raw-epss.tar.zst
             rm -rf vuls-data-raw-epss/ vuls-data-raw-epss.tar.zst
-            
+
             tags+=("\"vuls-data-raw-epss-archive-$(( ${y} - 2020 ))\"")
 
           done
@@ -64,6 +65,7 @@ jobs:
           mv $(date "+%Y") vuls-data-raw-epss
 
           git -C vuls-data-raw-epss -c init.defaultBranch=main init .
+          git -C vuls-data-raw-epss config gc.auto 0
           
           if git -C vuls-data-raw-epss remote | grep -q "^origin$"; then
             git -C vuls-data-raw-epss remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -277,7 +277,7 @@ jobs:
         id: split_archive
         run: |
           echo "Create the latest repository..."
-          git clone --depth 1 --no-single-branch --no-checkout --branch main file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
+          git clone --depth 1 --no-single-branch --no-checkout --branch main --config gc.auto=0 file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
           if git -C ${{ inputs.tag }} remote | grep -q "^origin$"; then
             git -C ${{ inputs.tag }} remote set-url origin ghcr.io/${{ github.repository }}:${{ inputs.tag }}
           else

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
           else

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -178,6 +178,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
           else

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-nvd-api-cve
           else

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}-rhel
           else

--- a/.github/workflows/extract-redhat-rhel-ovalv1.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv1.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv1-rhel
           else

--- a/.github/workflows/extract-redhat-rhel-ovalv2.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv2.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv2-rhel
           else

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
           else

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
           else

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
           else

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss
           else

--- a/.github/workflows/fetch-fedora.yml
+++ b/.github/workflows/fetch-fedora.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fedora
           else

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
           else

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -88,6 +88,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
           else

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -197,6 +197,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -131,6 +131,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
           else

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
           else

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Set Git config
         run: |
+          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,6 +46,17 @@ jobs:
           path: ${{ inputs.target }}
           fetch-depth: "0"
 
+      - name: Set Git config
+        run: |
+          git -C ${{ inputs.target }} config gc.auto 0
+          if git -C ${{ inputs.target }} remote | grep -q "^origin$"; then
+            git -C ${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:${{ inputs.target }}
+          else
+            git -C ${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:${{ inputs.target }}
+          fi
+          git -C ${{ inputs.target }} config user.email "action@github.com"
+          git -C ${{ inputs.target }} config user.name "GitHub Action"
+
       - name: Create dotgit tarball
         run: vuls-data-update dotgit compress ${{ inputs.target }}
 

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Truncate dotgit
         run: |
           echo "Create the trucated repository..."
-          git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
+          git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main --config gc.auto 0 file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
           git -C ${{ inputs.tag }} reset
           git -C ${{ inputs.tag }} branch nightly origin/nightly
 


### PR DESCRIPTION
To prevent the error triggered by background Git GC, add "gc.auto" confing with value 0.

--------

https://github.com/vulsio/vuls-data-db/actions/runs/20321963528/job/58379457748#step:11:92

The log below shows file name `ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval/.git/objects/pack/tmp_pack_RV3o44`. The prefix `tmp_pack_` indicates Git GC was running background in "dotgit compress"'ing.  The file must grow bigger than it has been at its tar header creation, so tar write exceeded the size in the header.

```
Run vuls-data-update dotgit compress ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval
  vuls-data-update dotgit compress ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval
  shell: /usr/bin/bash -e {0}
  env:
    GOEXPERIMENT: jsonv2
    GOTOOLCHAIN: local
2025/12/18 01:54:57 [INFO] Compress ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval dotgit to vuls-data-raw-suse-oval.tar.zst
archive/tar: write too long
copy ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval/.git/objects/pack/tmp_pack_RV3o44
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.options.compress.func1
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/dotgit/compress/compress.go:148
path/filepath.walkDir
	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:310
path/filepath.walkDir
	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
path/filepath.walkDir
	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
path/filepath.walkDir
	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:332
path/filepath.WalkDir
	/opt/hostedtoolcache/go/1.25.5/x64/src/path/filepath/path.go:400
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.options.compress
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/dotgit/compress/compress.go:105
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.Compress
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/dotgit/compress/compress.go:66
github.com/MaineK00n/vuls-data-update/pkg/cmd/dotgit.newCmdCompress.func2
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/dotgit/compress.go:52
github.com/spf13/cobra.(*Command).execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
runtime.main
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
runtime.goexit
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
walk ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.options.compress
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/dotgit/compress/compress.go:154
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.Compress
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/dotgit/compress/compress.go:66
github.com/MaineK00n/vuls-data-update/pkg/cmd/dotgit.newCmdCompress.func2
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/dotgit/compress.go:52
github.com/spf13/cobra.(*Command).execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
runtime.main
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
runtime.goexit
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
compress ghcr.io/vulsio/vuls-data-db/vuls-data-raw-suse-oval to vuls-data-raw-suse-oval.tar.zst
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.Compress
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/dotgit/compress/compress.go:70
github.com/MaineK00n/vuls-data-update/pkg/cmd/dotgit.newCmdCompress.func2
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/dotgit/compress.go:52
github.com/spf13/cobra.(*Command).execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
runtime.main
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
runtime.goexit
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
failed to dotgit compress
github.com/MaineK00n/vuls-data-update/pkg/cmd/dotgit.newCmdCompress.func2
	/home/runner/work/vuls-data-db/vuls-data-db/pkg/cmd/dotgit/compress.go:53
github.com/spf13/cobra.(*Command).execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
	/home/runner/work/vuls-data-db/vuls-data-db/cmd/vuls-data-update/main.go:11
runtime.main
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/proc.go:285
runtime.goexit
	/opt/hostedtoolcache/go/1.25.5/x64/src/runtime/asm_amd64.s:1693
Error: Process completed with exit code 1.
```

--------------

Experiment of `--config gc.auto=0` option for "git clone":

```
[0]% git clone --depth 1 --no-single-branch --no-checkout --branch main --config gc.auto=0  file://${PWD}/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-oracle-linux cl
Cloning into 'cl'...
remote: Enumerating objects: 16232, done.
remote: Counting objects: 100% (16232/16232), done.
remote: Compressing objects: 100% (685/685), done.
remote: Total 16232 (delta 15802), reused 15697 (delta 15547), pack-reused 0 (from 0)
Receiving objects: 100% (16232/16232), 13.15 MiB | 31.04 MiB/s, done.
Resolving deltas: 100% (15802/15802), done.
[0]% cat cl/.git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
[gc]
        auto = 0                   # <== HERE IT IS
[remote "origin"]
        url = file:///home/shino/t/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-oracle-linux
        fetch = +refs/heads/*:refs/remotes/origin/*
[branch "main"]
        remote = origin
        merge = refs/heads/main
```