### PR TITLE
fix(ci/truncate): add missing equal sign

### DIFF
--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Truncate dotgit
         run: |
           echo "Create the trucated repository..."
-          git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main --config gc.auto 0 file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
+          git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main --config gc.auto=0 file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
           git -C ${{ inputs.tag }} reset
           git -C ${{ inputs.tag }} branch nightly origin/nightly
 


### PR DESCRIPTION
`=` is missing in "git clone"'s "--config gc.auto=0".

One more similar line was OK.
https://github.com/vulsio/vuls-data-db/blob/7ea73c7f7959eb3f43604f542cbfd2ed5398aab2/.github/workflows/archive.yml#L280

Error:
https://github.com/vulsio/vuls-data-db/actions/runs/20510157150/job/58931084868#step:7:1
```
un echo "Create the trucated repository..."
  echo "Create the trucated repository..."
  git clone --depth 36 --no-single-branch --no-checkout --branch main --config gc.auto 0 file://${PWD}/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-epss vuls-data-extracted-epss
  git -C vuls-data-extracted-epss reset
  git -C vuls-data-extracted-epss branch nightly origin/nightly
  
  rm -rf ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-epss
  vuls-data-update dotgit compress vuls-data-extracted-epss
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GOEXPERIMENT: jsonv2
    GOTOOLCHAIN: local
Create the trucated repository...
fatal: Too many arguments.

usage: git clone [<options>] [--] <repo> [<dir>]

    -v, --[no-]verbose    be more verbose
    -q, --[no-]quiet      be more quiet
[snip]
```

----------

reproduction on local env.

No `=`:
```
[0]% git clone --depth 36 --no-single-branch --no-checkout --branch main --config gc.auto 0 file://${PWD}/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-epss vuls-data-extracted-eps 2>&1 | head -5
fatal: Too many arguments.

usage: git clone [<options>] [--] <repo> [<dir>]

    -v, --[no-]verbose    be more verbose
```

With `=`:
```
[0]% git clone --depth 36 --no-single-branch --no-checkout --branch main --config gc.auto=0 file://${PWD}/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-epss vuls-data-extracted-eps 2>&1 | head -5
Cloning into 'vuls-data-extracted-eps'...
[0]%                      
```