### PR TITLE
chore(ci): add check-failures workflow

### DIFF
--- a/.github/workflows/check-failures.yml
+++ b/.github/workflows/check-failures.yml
@@ -1,0 +1,103 @@
+name: Check Failures
+
+on:
+  workflow_call: {}
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID to check (blank = current run)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  report:
+    name: Failure summary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect failure summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          RUN_ID="${{ inputs.run_id || github.run_id }}"
+
+          # --- fetch run metadata -----------------------------------------------
+          run_json=$(gh run view "$RUN_ID" --json 'databaseId,createdAt,url,jobs,name')
+
+          wf_name=$(echo "$run_json" | jq -r '.name // "Unknown"')
+          url=$(echo "$run_json" | jq -r '.url')
+          created=$(echo "$run_json" | jq -r '.createdAt')
+
+          {
+            echo "# 🔍 ${wf_name} — Failure Report"
+            echo ""
+            echo "_Run [#${RUN_ID}](${url}) | started ${created} | checked $(date -u +'%Y-%m-%d %H:%M:%S') UTC_"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # --- collect failed jobs ------------------------------------------------
+          failed_jobs=$(echo "$run_json" \
+            | jq -r '.jobs[] | select(.conclusion == "failure") | "\(.name)"')
+
+          n_failed=$(echo "$failed_jobs" | grep -c . || true)
+
+          if [[ "$n_failed" -eq 0 ]]; then
+            echo "✅ All jobs succeeded." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "### ❌ Failed jobs (${n_failed})"
+            echo ""
+            echo "| Job | Error snippet |"
+            echo "|-----|---------------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # --- get failed logs ----------------------------------------------------
+          log_file=$(mktemp)
+          gh run view "$RUN_ID" --log-failed > "$log_file" 2>/dev/null || true
+
+          while IFS= read -r job_name; do
+            snippet=""
+            if [[ -s "$log_file" ]]; then
+              # gh --log-failed format: "<job_name>\t<step>\t<message>"
+              # Filter lines belonging to this job, then extract error-related lines
+              snippet=$(awk -F'\t' -v job="$job_name" '$1 == job { print $3 }' "$log_file" \
+                | grep -iE "error[^s_-]|error$|panic|fatal|exception|timed? ?out|: fail|exit (code|status)" \
+                | tail -20 \
+                | head -c 3000 || true)
+            fi
+
+            if [[ -z "$snippet" ]]; then
+              snippet="(no recognisable error lines captured)"
+            fi
+
+            # Escape HTML special chars, then convert newlines to <br> so the
+            # Markdown table row stays on a single line.
+            snippet=$(echo "$snippet" \
+              | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/|/｜/g; s/`/｀/g' \
+              | tr '\n' '\r' \
+              | sed 's/\r/<br>/g')
+
+            echo "| ${job_name} | <details><summary>show</summary><pre>${snippet}</pre></details> |" >> "$GITHUB_STEP_SUMMARY"
+          done <<< "$failed_jobs"
+
+          # --- full context -------------------------------------------------------
+          {
+            echo ""
+            echo "<details><summary>Full failed-log extract (up to 200 lines)</summary>"
+            echo ""
+            echo '```'
+            head -200 "$log_file" || true
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          rm -f "$log_file"


### PR DESCRIPTION
Add job failure check workflow.

Finally, I want to add such jobs to several existing workflows as https://github.com/vulsio/vuls-data-db/commit/2c0c34fa4a184bb9b40f15b1359bd0848aded9bf , 
I plan to add the check workflow in this PR and merge it to main branch, to run the newly added workflow and debug.
Then glue calls from Fetch All etc. will be added in the following PR.