### PR TITLE
fix(ci/fetch-fortinet*): filter only starting with 'FG-IR-'

### DIFF
--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -70,12 +70,12 @@ jobs:
 
       - name: Fetch All
         if: ${{ needs.check.outputs.do_fetch_all == 'true' }}
-        run: vuls-data-update fetch fortinet-csaf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf --concurrency 1 --wait 3s $(sort <(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename) <(find ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf/ -name "*.json" | xargs -I {} sh -c "basename {} .json") | uniq | tr '\n' ' ')
+        run: vuls-data-update fetch fortinet-csaf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf --concurrency 1 --wait 3s $(sort <(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | grep '^FG-IR-') <(find ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf/ -name "*.json" | xargs -I {} sh -c "basename {} .json") | uniq | tr '\n' ' ')
 
       - name: Fetch RSS
         if: ${{ needs.check.outputs.do_fetch_all != 'true' }}
         run: |
-          vuls-data-update fetch fortinet-csaf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf --concurrency 1 $(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | tr '\n' ' ')
+          vuls-data-update fetch fortinet-csaf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf --concurrency 1 $(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | grep '^FG-IR-' | tr '\n' ' ')
 
       - name: Restore all deleted files
         if: ${{ needs.check.outputs.do_fetch_all != 'true' }}

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Fetch All
         if: ${{ needs.check.outputs.do_fetch_all == 'true' }}
-        run: vuls-data-update fetch fortinet-cvrf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf --concurrency 1 --wait 3s $(sort <(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename) <(find ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf/ -name "*.json" | xargs -I {} sh -c "basename {} .json") | uniq | grep -Ev '^(FG-IR-012-00[1-8]|FG-IR-013-001)$' | tr '\n' ' ')
+        run: vuls-data-update fetch fortinet-cvrf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf --concurrency 1 --wait 3s $(sort <(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | grep '^FG-IR-') <(find ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf/ -name "*.json" | xargs -I {} sh -c "basename {} .json") | uniq | grep -Ev '^(FG-IR-012-00[1-8]|FG-IR-013-001)$' | tr '\n' ' ')
 
       - name: Restore FG-IR-012-00[1-8]|FG-IR-013-001
         if: ${{ needs.check.outputs.do_fetch_all == 'true' }}
@@ -80,7 +80,7 @@ jobs:
       - name: Fetch RSS
         if: ${{ needs.check.outputs.do_fetch_all != 'true' }}
         run: |
-          vuls-data-update fetch fortinet-cvrf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf --concurrency 1 $(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | tr '\n' ' ')
+          vuls-data-update fetch fortinet-cvrf --dir ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf --concurrency 1 $(curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename | grep '^FG-IR-' | tr '\n' ' ')
 
       - name: Restore all deleted files
         if: ${{ needs.check.outputs.do_fetch_all != 'true' }}


### PR DESCRIPTION
The fetch fails because "#5575" is received when "FG-IR-*" is expected.
```console
$ curl https://filestore.fortinet.com/fortiguard/rss/ir.xml | xq -x //item/link | xargs -L 1 basename
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 37219  100 37219    0     0   111k      0 --:--:-- --:--:-- --:--:--  111k
FG-IR-26-076
FG-IR-25-084
#5575
FG-IR-25-661
FG-IR-25-384
FG-IR-25-795
FG-IR-25-1052
FG-IR-25-528
FG-IR-25-667
FG-IR-25-934
FG-IR-25-093
FG-IR-25-1142
FG-IR-26-060
FG-IR-25-778
FG-IR-25-735
FG-IR-25-783
FG-IR-25-260
FG-IR-25-772
FG-IR-23-494
FG-IR-24-133
FG-IR-25-601
FG-IR-25-945
FG-IR-25-984
FG-IR-25-599
FG-IR-25-032
FG-IR-24-268
FG-IR-25-411
FG-IR-25-554
FG-IR-25-647
FG-IR-25-739
FG-IR-25-362
FG-IR-25-454
FG-IR-25-479
FG-IR-25-812
FG-IR-25-616
FG-IR-25-477
FG-IR-25-122
FG-IR-25-632
FG-IR-25-358
FG-IR-25-112
FG-IR-25-251
FG-IR-25-125
FG-IR-25-634
FG-IR-25-789
FG-IR-25-259
FG-IR-24-501
FG-IR-25-844
FG-IR-25-686
FG-IR-25-513
FG-IR-25-225

$ curl https://filestore.fortinet.com/fortiguard/rss/ir.xml
...<item><title>SQL injection in forward module</title><link>https://fortiguard.fortinet.com/psirt/#5575</link><description><![CDATA[]]></description><guid isPermaLink="true">https://fortiguard.fortinet.com/psirt/#5575</guid><pubDate>Sat, 21 Feb 2026 00:41:45 -0800</pubDate></item>...
```

https://github.com/vulsio/vuls-data-db/actions/runs/22377264354/job/64770627081#step:9:248
https://github.com/vulsio/vuls-data-db/actions/runs/22377264354/job/64770484699#step:10:237