### PR TITLE
chore(ci/db-nightly): add diff guard before shipping

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -6,7 +6,7 @@ description: |
   failing the job if any check exceeds its configured threshold.
 
   All guard steps are kept inside this composite action so the caller only
-  needs a single `if:` to skip the whole gate (e.g. `force=true`).
+  needs a single `uses:` step to run the whole gate.
 
   Sanity-check strategy (the order steps run in):
     1. Detection against vuls0 master HEAD — a large detection gap almost
@@ -15,9 +15,9 @@ description: |
        regressions that only surface against past vuls0 versions.
     3. `vuls diff db` last — structural changes to the extracted data can
        legitimately inflate the raw DB diff even when detection is stable.
-       If detection shows near-zero change but only `diff db` fails and the
-       cause is well understood, the caller can re-run with `force=true` to
-       skip this guard entirely and proceed with the publish.
+       If detection shows near-zero change but only `diff db` fails, the
+       failure is easier to interpret because the earlier detection checks
+       already established detection stability.
 
 inputs:
   target_db:

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -20,23 +20,23 @@ description: |
        skip this guard entirely and proceed with the publish.
 
 inputs:
-  target-db:
+  target_db:
     description: Path to the freshly built vuls.db to validate.
     required: true
-  baseline-repository:
+  baseline_repository:
     description: OCI reference (repo:tag) to fetch the baseline vuls.db from.
     required: true
-  db-change-rate-threshold:
+  db_change_rate_threshold:
     description: "`vuls diff db` change rate (%) threshold per ecosystem."
     required: true
-  detection-change-rate-threshold:
+  detection_change_rate_threshold:
     description: "`vuls diff detection` change rate (%) threshold per scan result."
     required: true
-  integration-ref:
+  integration_ref:
     description: vulsio/integration commit SHA to pin scan-result fixtures to.
     required: false
     default: 24c96d27ea0ead49ad8311d8c92d204fef5c58b4
-  vuls0-old-ref:
+  vuls0_old_ref:
     description: future-architect/vuls commit SHA for the older-binary detection check.
     required: false
     default: 4cc910824a2880fbfb322dd4e9d94b68558bed57
@@ -50,18 +50,16 @@ runs:
         # Diff behavior (thresholds, output format) can change across vuls2
         # nightlies, so capture the exact binary being used to drive
         # `vuls diff ...` alongside the vuls0 binaries recorded below.
-        vuls_bin=$(command -v vuls)
         {
           echo "## vuls (vuls2) driving diff checks"
           echo '```text'
-          echo "path: ${vuls_bin}"
-          go version -m "${vuls_bin}" 2>&1 | awk '$1=="mod" && $2=="github.com/MaineK00n/vuls2"' || true
+          go version -m "$(command -v vuls)" 2>&1 | awk '$1=="mod" && $2=="github.com/MaineK00n/vuls2"' || true
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Fetch baseline vuls.db
       shell: bash
-      run: vuls db fetch --dbpath ./baseline.db --repository "${{ inputs.baseline-repository }}" --no-progress
+      run: vuls db fetch --dbpath ./baseline.db --repository "${{ inputs.baseline_repository }}" --no-progress
 
     - name: Install vuls0 (future-architect/vuls master)
       shell: bash
@@ -88,7 +86,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: vulsio/integration
-        ref: ${{ inputs.integration-ref }}
+        ref: ${{ inputs.integration_ref }}
         path: integration
 
     - name: Prepare scan results (vuls2-supported families only)
@@ -109,8 +107,8 @@ runs:
     - name: Diff detection between baseline and target DBs
       shell: bash
       env:
-        TARGET_DB: ${{ inputs.target-db }}
-        DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection-change-rate-threshold }}
+        TARGET_DB: ${{ inputs.target_db }}
+        DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
       run: |
         set +e
         set -o pipefail
@@ -133,7 +131,7 @@ runs:
     - name: Install vuls0 for older-binary check (pinned commit)
       shell: bash
       env:
-        VULS0_OLD_REF: ${{ inputs.vuls0-old-ref }}
+        VULS0_OLD_REF: ${{ inputs.vuls0_old_ref }}
       run: |
         mkdir -p /tmp/vuls0-old-bin
         GOBIN=/tmp/vuls0-old-bin go install "github.com/future-architect/vuls/cmd/vuls@${VULS0_OLD_REF}"
@@ -154,7 +152,7 @@ runs:
         # and additionally remove families the pinned older vuls0 cannot
         # process. This is expressed as a *blacklist* so new families added
         # upstream are retained automatically; only known-broken ones need
-        # listing here. Update this set when bumping `vuls0-old-ref`.
+        # listing here. Update this set when bumping `vuls0_old_ref`.
         mkdir -p ./scan-results-old
         cp ./scan-results/*.json ./scan-results-old/
         rm -f \
@@ -169,9 +167,9 @@ runs:
     - name: Diff detection with older vuls0 binary (baseline vs target DB)
       shell: bash
       env:
-        TARGET_DB: ${{ inputs.target-db }}
-        DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection-change-rate-threshold }}
-        VULS0_OLD_REF: ${{ inputs.vuls0-old-ref }}
+        TARGET_DB: ${{ inputs.target_db }}
+        DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
+        VULS0_OLD_REF: ${{ inputs.vuls0_old_ref }}
       run: |
         set +e
         set -o pipefail
@@ -192,8 +190,8 @@ runs:
     - name: Diff vuls.db against baseline
       shell: bash
       env:
-        TARGET_DB: ${{ inputs.target-db }}
-        DB_CHANGE_RATE_THRESHOLD: ${{ inputs.db-change-rate-threshold }}
+        TARGET_DB: ${{ inputs.target_db }}
+        DB_CHANGE_RATE_THRESHOLD: ${{ inputs.db_change_rate_threshold }}
       run: |
         set +e
         set -o pipefail

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -1,0 +1,209 @@
+name: diff-guard
+description: |
+  Compare a freshly built vuls.db against a baseline pulled from a container
+  registry. Runs `vuls diff detection` (against two vuls0 binaries: master HEAD
+  and a pinned older commit) and `vuls diff db`, emitting step summaries and
+  failing the job if any check exceeds its configured threshold.
+
+  All guard steps are kept inside this composite action so the caller only
+  needs a single `if:` to skip the whole gate (e.g. `force=true`).
+
+  Sanity-check strategy (the order steps run in):
+    1. Detection against vuls0 master HEAD — a large detection gap almost
+       always means the DB should not ship.
+    2. Detection against a slightly older pinned vuls0 binary — catches
+       regressions that only surface against past vuls0 versions.
+    3. `vuls diff db` last — structural changes to the extracted data can
+       legitimately inflate the raw DB diff even when detection is stable.
+       If detection shows near-zero change but only `diff db` fails and the
+       cause is well understood, the caller can re-run with `force=true` to
+       skip this guard entirely and proceed with the publish.
+
+inputs:
+  target-db:
+    description: Path to the freshly built vuls.db to validate.
+    required: true
+  baseline-repository:
+    description: OCI reference (repo:tag) to fetch the baseline vuls.db from.
+    required: true
+  db-change-rate-threshold:
+    description: "`vuls diff db` change rate (%) threshold per ecosystem."
+    required: true
+  detection-change-rate-threshold:
+    description: "`vuls diff detection` change rate (%) threshold per scan result."
+    required: true
+  integration-ref:
+    description: vulsio/integration commit SHA to pin scan-result fixtures to.
+    required: false
+    default: 24c96d27ea0ead49ad8311d8c92d204fef5c58b4
+  vuls0-old-ref:
+    description: future-architect/vuls commit SHA for the older-binary detection check.
+    required: false
+    default: 4cc910824a2880fbfb322dd4e9d94b68558bed57
+
+runs:
+  using: composite
+  steps:
+    - name: Record vuls (vuls2) binary metadata
+      shell: bash
+      run: |
+        # Diff behavior (thresholds, output format) can change across vuls2
+        # nightlies, so capture the exact binary being used to drive
+        # `vuls diff ...` alongside the vuls0 binaries recorded below.
+        vuls_bin=$(command -v vuls)
+        {
+          echo "## vuls (vuls2) driving diff checks"
+          echo '```text'
+          echo "path: ${vuls_bin}"
+          go version -m "${vuls_bin}" 2>&1 | awk '$1=="mod" && $2=="github.com/MaineK00n/vuls2"' || true
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Fetch baseline vuls.db
+      shell: bash
+      run: vuls db fetch --dbpath ./baseline.db --repository "${{ inputs.baseline-repository }}" --no-progress
+
+    - name: Install vuls0 (future-architect/vuls master)
+      shell: bash
+      run: |
+        mkdir -p /tmp/vuls0-bin
+        GOBIN=/tmp/vuls0-bin go install github.com/future-architect/vuls/cmd/vuls@master
+        mv /tmp/vuls0-bin/vuls /tmp/vuls0-bin/vuls0
+        echo "VULS0=/tmp/vuls0-bin/vuls0" >> "$GITHUB_ENV"
+
+        # `go version -m` reads the module metadata Go embeds into every
+        # binary; the `mod` line's pseudo-version carries both the build
+        # timestamp and short commit hash
+        # (e.g. `v0.38.7-0.YYYYMMDDHHMMSS-<shorthash>`).
+        {
+          echo "## vuls0 under test (master HEAD)"
+          echo '```text'
+          go version -m /tmp/vuls0-bin/vuls0 2>&1 | awk '$1=="mod" && $2=="github.com/future-architect/vuls"' || true
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    # Pin vulsio/integration to a specific commit so scan-result fixtures used
+    # by `vuls diff detection` do not change independently of this repo.
+    - name: Check out vulsio/integration (pinned) for scan-result fixtures
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        repository: vulsio/integration
+        ref: ${{ inputs.integration-ref }}
+        path: integration
+
+    - name: Prepare scan results (vuls2-supported families only)
+      shell: bash
+      run: |
+        mkdir -p ./scan-results
+        # Copy all scan results then drop the ones excluded from this vuls2
+        # detection diff: Windows (handled by gost) and CentOS — see
+        # vuls/detector/detector.go DetectPkgCves switch.
+        cp ./integration/data/results/*.json ./scan-results/
+        rm -f ./scan-results/windows_*.json ./scan-results/centos_*.json
+        ls -1 ./scan-results
+
+        integration_sha=$(git -C ./integration rev-parse HEAD)
+        echo "## Scan-result fixtures source" >> "$GITHUB_STEP_SUMMARY"
+        echo "- vulsio/integration @ \`${integration_sha}\`" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Diff detection between baseline and target DBs
+      shell: bash
+      env:
+        TARGET_DB: ${{ inputs.target-db }}
+        DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection-change-rate-threshold }}
+      run: |
+        set +e
+        set -o pipefail
+        vuls diff detection \
+          ./scan-results \
+          ./baseline.db "$VULS0" \
+          "$TARGET_DB" "$VULS0" \
+          --change-rate-threshold "$DETECTION_CHANGE_RATE_THRESHOLD" \
+          | tee ./diff-detection-report.md
+        rc=$?
+        set -e
+
+        echo "---" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (vuls0 master HEAD)" >> "$GITHUB_STEP_SUMMARY"
+        head -n 100 ./diff-detection-report.md >> "$GITHUB_STEP_SUMMARY"
+        exit "$rc"
+
+    # Additional check with a slightly older vuls0 binary (pinned commit) to
+    # catch regressions that only surface against past vuls0 versions.
+    - name: Install vuls0 for older-binary check (pinned commit)
+      shell: bash
+      env:
+        VULS0_OLD_REF: ${{ inputs.vuls0-old-ref }}
+      run: |
+        mkdir -p /tmp/vuls0-old-bin
+        GOBIN=/tmp/vuls0-old-bin go install "github.com/future-architect/vuls/cmd/vuls@${VULS0_OLD_REF}"
+        mv /tmp/vuls0-old-bin/vuls /tmp/vuls0-old-bin/vuls0-old
+        echo "VULS0_OLD=/tmp/vuls0-old-bin/vuls0-old" >> "$GITHUB_ENV"
+
+        {
+          echo "## vuls0 under test (older pinned @${VULS0_OLD_REF:0:7})"
+          echo '```text'
+          go version -m /tmp/vuls0-old-bin/vuls0-old 2>&1 | awk '$1=="mod" && $2=="github.com/future-architect/vuls"' || true
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Prepare scan results for older-binary check (drop families unsupported by older vuls0)
+      shell: bash
+      run: |
+        # Start from the already-filtered master-HEAD set (windows/centos gone)
+        # and additionally remove families the pinned older vuls0 cannot
+        # process. This is expressed as a *blacklist* so new families added
+        # upstream are retained automatically; only known-broken ones need
+        # listing here. Update this set when bumping `vuls0-old-ref`.
+        mkdir -p ./scan-results-old
+        cp ./scan-results/*.json ./scan-results-old/
+        rm -f \
+          ./scan-results-old/amazon_*.json \
+          ./scan-results-old/debian_*.json \
+          ./scan-results-old/leap.json \
+          ./scan-results-old/opensuse_*.json \
+          ./scan-results-old/sles*.json \
+          ./scan-results-old/suse_*.json
+        ls -1 ./scan-results-old
+
+    - name: Diff detection with older vuls0 binary (baseline vs target DB)
+      shell: bash
+      env:
+        TARGET_DB: ${{ inputs.target-db }}
+        DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection-change-rate-threshold }}
+        VULS0_OLD_REF: ${{ inputs.vuls0-old-ref }}
+      run: |
+        set +e
+        set -o pipefail
+        vuls diff detection \
+          ./scan-results-old \
+          ./baseline.db "$VULS0_OLD" \
+          "$TARGET_DB" "$VULS0_OLD" \
+          --change-rate-threshold "$DETECTION_CHANGE_RATE_THRESHOLD" \
+          | tee ./diff-detection-old-report.md
+        rc=$?
+        set -e
+
+        echo "---" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7})" >> "$GITHUB_STEP_SUMMARY"
+        head -n 100 ./diff-detection-old-report.md >> "$GITHUB_STEP_SUMMARY"
+        exit "$rc"
+
+    - name: Diff vuls.db against baseline
+      shell: bash
+      env:
+        TARGET_DB: ${{ inputs.target-db }}
+        DB_CHANGE_RATE_THRESHOLD: ${{ inputs.db-change-rate-threshold }}
+      run: |
+        set +e
+        set -o pipefail
+        vuls diff db ./baseline.db "$TARGET_DB" \
+          --change-rate-threshold "$DB_CHANGE_RATE_THRESHOLD" \
+          | tee ./diff-report.md
+        rc=$?
+        set -e
+
+        echo "---" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff vuls.db" >> "$GITHUB_STEP_SUMMARY"
+        head -n 300 ./diff-report.md >> "$GITHUB_STEP_SUMMARY"
+        exit "$rc"

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -4,6 +4,20 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      db_change_rate_threshold:
+        description: "`vuls diff db` change rate (%) threshold per ecosystem; diff fails if exceeded"
+        required: false
+        default: "10"
+      detection_change_rate_threshold:
+        description: "`vuls diff detection` change rate (%) threshold per scan result; diff fails if exceeded"
+        required: false
+        default: "5"
+      force:
+        description: "**DANGER** Skip diff checks and proceed regardless"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -17,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOEXPERIMENT: jsonv2
+      # Publish target. Production: ghcr.io/vulsio/vuls-nightly-db:nightly.
+      PUBLISH_REPO: ghcr.io/vulsio/vuls-nightly-db
+      PROMOTE_TAG: nightly
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
@@ -54,8 +71,62 @@ jobs:
       - name: Compact vuls.db
         run: vuls db compress --dbpath ./vuls.db
 
-      - name: Upload vuls.db to ghcr.io/vulsio/vuls-nightly-db
-        run: vuls db push --force --token ${{ secrets.GITHUB_TOKEN }} ghcr.io/vulsio/vuls-nightly-db:nightly ./vuls.db.zst
+      # Design: "always push tagless, operate by digest, promote to :nightly only on pass".
+      # The candidate manifest is pushed BEFORE the guard runs so that a
+      # failing build remains pullable by digest for investigation; the
+      # :nightly tag is moved onto the verified digest only when the guard
+      # step below passes.
+      - name: Push vuls.db to GHCR (tagless, digest-only)
+        id: push
+        run: |
+          set -euo pipefail
+          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" "${PUBLISH_REPO}" ./vuls.db.zst)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Pushed candidate image (untagged, digest-only)"
+            echo '```text'
+            echo "digest ref : ${PUBLISH_REPO}@${digest}"
+            echo '```'
+            echo "Image is always pushed before the diff guard runs; a failing"
+            echo "build stays pullable by digest for investigation."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Runs on every scheduled invocation. If a legitimate change trips the
+      # guard and blocking the publish is not desired, this step can be
+      # bypassed by manually dispatching the workflow with `force=true` —
+      # see `.github/actions/diff-guard` for the check strategy and when
+      # that escape hatch is appropriate.
+      - name: Run diff guard
+        # On scheduled runs, github.event.inputs.* is typically unset/null
+        # rather than an empty string. The `!= 'true'` comparison and the
+        # `|| 'default'` fallbacks below let this workflow run without
+        # workflow_dispatch inputs.
+        if: ${{ github.event.inputs.force != 'true' }}
+        uses: ./.github/actions/diff-guard
+        with:
+          target-db: ./vuls.db
+          baseline-repository: ghcr.io/vulsio/vuls-nightly-db:nightly
+          db-change-rate-threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
+          detection-change-rate-threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
+
+      # Guard passed (or was skipped via force=true): attach :nightly to the
+      # verified digest. If the guard fails this step is skipped and
+      # :nightly stays pointing at the previous verified digest.
+      - name: Promote digest to :nightly
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          vuls-data-update dotgit registry tag \
+            --token "${{ secrets.GITHUB_TOKEN }}" \
+            "${PUBLISH_REPO}@${DIGEST}" "${PROMOTE_TAG}"
+          {
+            echo "## Promoted to :${PROMOTE_TAG}"
+            echo '```text'
+            echo "ref        : ${PUBLISH_REPO}:${PROMOTE_TAG}"
+            echo "digest ref : ${PUBLISH_REPO}@${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   action-run-summary:
     name: Action run summary

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -31,9 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOEXPERIMENT: jsonv2
-      # Publish target. Production: ghcr.io/vulsio/vuls-nightly-db:nightly.
-      PUBLISH_REPO: ghcr.io/vulsio/vuls-nightly-db
-      PROMOTE_TAG: nightly
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
@@ -80,12 +77,12 @@ jobs:
         id: push
         run: |
           set -euo pipefail
-          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" "${PUBLISH_REPO}" ./vuls.db.zst)
+          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" ghcr.io/vulsio/vuls-nightly-db ./vuls.db.zst)
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
           {
             echo "## Pushed candidate image (untagged, digest-only)"
             echo '```text'
-            echo "digest ref : ${PUBLISH_REPO}@${digest}"
+            echo "digest ref : ghcr.io/vulsio/vuls-nightly-db@${digest}"
             echo '```'
             echo "Image is always pushed before the diff guard runs; a failing"
             echo "build stays pullable by digest for investigation."
@@ -104,10 +101,10 @@ jobs:
         if: ${{ github.event.inputs.force != 'true' }}
         uses: ./.github/actions/diff-guard
         with:
-          target-db: ./vuls.db
-          baseline-repository: ghcr.io/vulsio/vuls-nightly-db:nightly
-          db-change-rate-threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
-          detection-change-rate-threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
+          target_db: ./vuls.db
+          baseline_repository: ghcr.io/vulsio/vuls-nightly-db:nightly
+          db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
+          detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
 
       # Guard passed (or was skipped via force=true): attach :nightly to the
       # verified digest. If the guard fails this step is skipped and
@@ -119,12 +116,12 @@ jobs:
           set -euo pipefail
           vuls-data-update dotgit registry tag \
             --token "${{ secrets.GITHUB_TOKEN }}" \
-            "${PUBLISH_REPO}@${DIGEST}" "${PROMOTE_TAG}"
+            "ghcr.io/vulsio/vuls-nightly-db@${DIGEST}" nightly
           {
-            echo "## Promoted to :${PROMOTE_TAG}"
+            echo "## Promoted to :nightly"
             echo '```text'
-            echo "ref        : ${PUBLISH_REPO}:${PROMOTE_TAG}"
-            echo "digest ref : ${PUBLISH_REPO}@${DIGEST}"
+            echo "ref        : ghcr.io/vulsio/vuls-nightly-db:nightly"
+            echo "digest ref : ghcr.io/vulsio/vuls-nightly-db@${DIGEST}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -13,11 +13,6 @@ on:
         description: "`vuls diff detection` change rate (%) threshold per scan result; diff fails if exceeded"
         required: false
         default: "5"
-      force:
-        description: "**DANGER** Skip diff checks and proceed regardless"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -88,17 +83,11 @@ jobs:
             echo "build stays pullable by digest for investigation."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Runs on every scheduled invocation. If a legitimate change trips the
-      # guard and blocking the publish is not desired, this step can be
-      # bypassed by manually dispatching the workflow with `force=true` —
-      # see `.github/actions/diff-guard` for the check strategy and when
-      # that escape hatch is appropriate.
+      # Runs on every scheduled and manually dispatched invocation.
       - name: Run diff guard
         # On scheduled runs, github.event.inputs.* is typically unset/null
-        # rather than an empty string. The `!= 'true'` comparison and the
-        # `|| 'default'` fallbacks below let this workflow run without
-        # workflow_dispatch inputs.
-        if: ${{ github.event.inputs.force != 'true' }}
+        # rather than an empty string. The `|| 'default'` fallbacks below
+        # let this workflow run without workflow_dispatch inputs.
         uses: ./.github/actions/diff-guard
         with:
           target_db: ./vuls.db
@@ -106,8 +95,8 @@ jobs:
           db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
           detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
 
-      # Guard passed (or was skipped via force=true): attach :nightly to the
-      # verified digest. If the guard fails this step is skipped and
+      # Guard passed: attach :nightly to the verified digest. If the guard
+      # fails this step is skipped and
       # :nightly stays pointing at the previous verified digest.
       - name: Promote digest to :nightly
         env:


### PR DESCRIPTION
## Summary

This PR adds a CI publish gate to vuls-data-db and switches the nightly publish flow to a digest-first promotion model.

The nightly workflow now always:
1. builds and compresses ./vuls.db
2. pushes the candidate image to GHCR without a tag
3. runs the diff guard against the current `:nightly` baseline
4. promotes the verified digest to `:nightly` only if the guard passes, ~or if the run is manually dispatched with `force=true`~

This keeps failed candidates pullable by digest for investigation while preventing the `:nightly` tag from moving onto an unverified DB.

---

## What This PR Changes

1. Adds `.github/actions/diff-guard`, a composite action that:
   - fetches the baseline DB from an OCI registry
   - runs `vuls diff detection` against two vuls0 binaries:
     - `future-architect/vuls@master`
     - a pinned older `future-architect/vuls` commit
   - runs `vuls diff db`
   - writes Markdown summaries to Job Summary and fails the job when any configured threshold is exceeded

2. Adds manual-dispatch controls to `db-nightly.yml`:
   - `db_change_rate_threshold`
   - `detection_change_rate_threshold`
   - ~`force`~

3. Reworks the nightly publish flow to "push tagless -> guard -> promote by digest":
   - `vuls db push` uploads the candidate manifest without a tag
   - the resulting digest is captured from stdout and passed through `GITHUB_OUTPUT`
   - guard and promote steps operate on `${PUBLISH_REPO}@<digest>`
   - `:nightly` is moved only after the candidate has been validated

4. Keeps the override path explicit:
   - ~setting `force=true` skips the composite guard~
   - the candidate manifest has already been pushed and remains pullable by digest for investigation

5. Records the exact validation inputs used by the guard:
   - the vuls2 binary driving `vuls diff ...`
   - the vuls0 `master` binary
   - the pinned older vuls0 binary
   - the pinned `vulsio/integration` fixture revision

---

## Sandbox Workflows (Validation Setup)

Before applying the guard to production workflow behavior, the design was validated in shino/sandbox with three dedicated workflow variants, each modeling the same post-build publish flow:

build/prepare -> tagless push -> diff guard -> promote `:nightly` on pass only

1. db-guard-test.yml (smoke / normal pass path)
- Baseline and target use the current nightly DB.
- Expected: detection checks pass, db diff check passes.

2. db-guard-fail-test-ubuntu-detection.yml (detection-fail scenario)
- Pins 2026-03-10 -> 2026-03-11 digests that trigger large Ubuntu detection churn.
- Expected: detection check fails (db diff is not reached).

3. db-guard-fail-test-redhat-db.yml (db-fail scenario)
- Pins 2026-03-03 -> 2026-03-04 digests that trigger large Red Hat drift.
- Detection steps are intentionally disabled so db diff fail behavior is isolated.
- Expected: db diff check fails.

The three workflow files share the same execution shape; differences are intentionally limited to:
- baseline/target repository pinning
- whether detection steps are enabled
- older-binary pin for compatibility simulation
- for redhat test, `diff detection` is skipped

---

## Latest Sandbox Action Runs (Reference)

These are the runs mapped one-to-one to the three workflows above:

1. Smoke test (db-guard-test.yml)
https://github.com/shino/sandbox/actions/runs/24826934517

2. Ubuntu detection fail (db-guard-fail-test-ubuntu-detection.yml)
https://github.com/shino/sandbox/actions/runs/24826935946
~Its `force` variant: https://github.com/shino/sandbox/actions/runs/24827320282~

3. Red Hat DB fail (db-guard-fail-test-redhat-db.yml)
https://github.com/shino/sandbox/actions/runs/24826937529

---

## Expected Production Behavior

- Every nightly run pushes an untagged candidate first and records its digest.
- If the guard passes, `:nightly` is moved to that verified digest.
- If the guard fails, the run fails and `:nightly` remains on the previous verified digest.
- ~If the workflow is manually dispatched with `force=true`, the guard is skipped and the already-pushed digest can still be promoted.~
- Full diff reports remain available in Job Summary and step logs for auditability.

---

## Rollout Plan

1. Merge this PR.
2. Monitor nightly threshold behavior and operator experience.
3. Apply the same digest-first guard pattern to the main workflow.
