### PR TITLE
fix(ci): consolidate git config into a single global step

### DIFF
--- a/.github/workflows/archive-epss.yml
+++ b/.github/workflows/archive-epss.yml
@@ -19,6 +19,13 @@ jobs:
     env:
       GOEXPERIMENT: jsonv2
     steps:
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -27,9 +34,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-epss
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-epss
@@ -47,10 +51,7 @@ jobs:
 
             mkdir vuls-data-raw-epss/
             mv ${y} vuls-data-raw-epss
-            git -C vuls-data-raw-epss -c init.defaultBranch=main init .
-            git -C vuls-data-raw-epss config gc.auto 0
-            git -C vuls-data-raw-epss config user.email "action@github.com"
-            git -C vuls-data-raw-epss config user.name "GitHub Action"
+            git -C vuls-data-raw-epss init .
             git -C vuls-data-raw-epss add ${y}
             git -C vuls-data-raw-epss commit -m "update" -m "GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}"
 
@@ -72,17 +73,14 @@ jobs:
           mkdir vuls-data-raw-epss/
           mv $(date "+%Y") vuls-data-raw-epss
 
-          git -C vuls-data-raw-epss -c init.defaultBranch=main init .
-          git -C vuls-data-raw-epss config gc.auto 0
-          
+          git -C vuls-data-raw-epss init .
+
           if git -C vuls-data-raw-epss remote | grep -q "^origin$"; then
             git -C vuls-data-raw-epss remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss
           else
             git -C vuls-data-raw-epss remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss
           fi
-          
-          git -C vuls-data-raw-epss config user.email "action@github.com"
-          git -C vuls-data-raw-epss config user.name "GitHub Action"
+
           git -C vuls-data-raw-epss add $(date "+%Y")
           git -C vuls-data-raw-epss commit -m "update" -m "GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}"
           

--- a/.github/workflows/archive-epss.yml
+++ b/.github/workflows/archive-epss.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-epss
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-epss
 

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -268,6 +268,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:${{ inputs.tag }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:${{ inputs.tag }}
 

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -259,6 +259,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -267,9 +274,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:${{ inputs.tag }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:${{ inputs.tag }}
@@ -293,7 +297,7 @@ jobs:
         id: split_archive
         run: |
           echo "Create the latest repository..."
-          git clone --depth 1 --no-single-branch --no-checkout --branch main --config gc.auto=0 file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
+          git clone --depth 1 --no-single-branch --no-checkout --branch main file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
           if git -C ${{ inputs.tag }} remote | grep -q "^origin$"; then
             git -C ${{ inputs.tag }} remote set-url origin ghcr.io/${{ github.repository }}:${{ inputs.tag }}
           else

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Extract
         run: vuls-data-update extract eol --dir ghcr.io/${{ github.repository }}/vuls-data-extracted-eol
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-eol

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -40,6 +40,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -54,9 +61,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
         run: vuls-data-update dotgit pull --dir . --checkout ${{ inputs.branch }} ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
 
@@ -65,14 +69,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-eol config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
         run: vuls-data-update dotgit pull --dir . --checkout ${{ inputs.branch }} ghcr.io/${{ github.repository }}:vuls-data-extracted-eol
 

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -163,6 +163,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -177,9 +184,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 
@@ -191,14 +195,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Extract
         run: vuls-data-update extract ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }}
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -40,6 +40,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -53,9 +60,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-nvd-api-cve
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-nvd-api-cve
@@ -71,14 +75,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-nvd-api-cve
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-nvd-api-cve
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-nvd-api-cve
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-nvd-api-cve
 

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Extract
         run: vuls-data-update extract nvd-api-cve --dir ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve ghcr.io/${{ github.repository }}/vuls-data-raw-nvd-api-cve ghcr.io/${{ github.repository }}/vuls-data-raw-nvd-api-cpematch
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-nvd-api-cve remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-nvd-api-cve

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout ${{ inputs.branch }} --restore ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
 

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Filter
         run: go run main.go ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} affected_repository_list.json ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}-rhel

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -49,6 +49,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -64,9 +71,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout ${{ inputs.branch }} --restore ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
 
@@ -78,14 +82,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}-rhel
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}-rhel
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }}-rhel config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-redhat-rhel-ovalv1.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv1.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Extract
         run: vuls-data-update extract redhat-ovalv1 --dir ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-ovalv1 ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-repository-to-cpe
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv1-rhel

--- a/.github/workflows/extract-redhat-rhel-ovalv1.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv1.yml
@@ -40,6 +40,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -53,9 +60,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv1
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv1
@@ -75,14 +79,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv1-rhel
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv1-rhel
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv1-rhel config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-redhat-rhel-ovalv1.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv1.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv1
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv1
 

--- a/.github/workflows/extract-redhat-rhel-ovalv2.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv2.yml
@@ -40,6 +40,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -53,9 +60,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv2
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv2
@@ -83,14 +87,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv2-rhel
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv2-rhel
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-redhat-rhel-ovalv2.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv2.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Extract
         run: vuls-data-update extract redhat-ovalv2 --dir ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-ovalv2 ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-repository-to-cpe
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-redhat-ovalv2-rhel remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-redhat-ovalv2-rhel

--- a/.github/workflows/extract-redhat-rhel-ovalv2.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv2.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv2
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-ovalv2
 

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -51,6 +51,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -64,9 +71,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
@@ -82,14 +86,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Extract
         run: vuls-data-update extract ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-repository-to-cpe
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-extracted-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-extracted-${{ inputs.target }}

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
 

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} $(find ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json/ -name "*.json" | xargs jq -r --arg target ${{ inputs.target }} 'select(($target == "cisco-cvrf" and .cvrfUrl != "NA") or ($target == "cisco-csaf" and .csafUrl != "NA")) | .advisoryId' | tr '\n' ' ')
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -40,6 +40,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -54,9 +61,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
 
@@ -68,14 +72,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -34,6 +34,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -48,9 +55,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
 
@@ -59,14 +63,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json
 

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch cisco-json --dir ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json ${{ secrets.CISCO_CLIENT_KEY }} ${{ secrets.CISCO_CLIENT_SECRET }}
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-cisco-json remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-cisco-json

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -54,6 +54,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -67,9 +74,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
@@ -92,14 +96,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list
 

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -94,7 +94,7 @@ jobs:
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list restore ${deleted}
           fi
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-enisa-euvd-list remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-enisa-euvd-list

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch epss --dir ghcr.io/${{ github.repository }}/vuls-data-raw-epss $(date --utc -d "-1 days" "+%Y-%m-%d")
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-epss
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-epss
 

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -29,6 +29,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -43,9 +50,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-epss
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-epss
 
@@ -54,14 +58,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-epss
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-epss config user.name "GitHub Action"
 
       - name: Restore
         run: |

--- a/.github/workflows/fetch-fedora-api.yml
+++ b/.github/workflows/fetch-fedora-api.yml
@@ -93,6 +93,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -101,9 +108,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api
@@ -120,14 +124,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-fedora-api.yml
+++ b/.github/workflows/fetch-fedora-api.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api
 

--- a/.github/workflows/fetch-fedora-api.yml
+++ b/.github/workflows/fetch-fedora-api.yml
@@ -122,7 +122,7 @@ jobs:
             rmdir ghcr.io/${{ github.repository }}/fedora-data-${release}
           done
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fedora-api remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fedora-api

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -54,6 +54,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -70,9 +77,6 @@ jobs:
 
       - name: Install xq
         run: go install github.com/sibprogrammer/xq@v1.4.0
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
@@ -93,14 +97,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Install xq
         run: go install github.com/sibprogrammer/xq@v1.4.0
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf
 

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf restore $(git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf ls-files --deleted)
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-csaf remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-csaf

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Install xq
         run: go install github.com/sibprogrammer/xq@v1.4.0
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
 

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -54,6 +54,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -70,9 +77,6 @@ jobs:
 
       - name: Install xq
         run: go install github.com/sibprogrammer/xq@v1.4.0
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
@@ -98,14 +102,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf restore $(git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf ls-files --deleted)
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-fortinet-cvrf remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-fortinet-cvrf

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -180,6 +180,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -194,9 +201,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 
@@ -209,14 +213,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }}
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -194,6 +194,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -128,7 +128,7 @@ jobs:
             rmdir "ghcr.io/${{ github.repository }}/microsoft-msuc-data-${name}"
           done < <(echo "$include" | jq -r '.[].name')
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
 

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -94,6 +94,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -102,9 +109,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
@@ -126,14 +130,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-microsoft-msuc
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-microsoft-msuc config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-nuclei-api.yml
+++ b/.github/workflows/fetch-nuclei-api.yml
@@ -32,6 +32,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -46,9 +53,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api
 
@@ -57,14 +61,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-nuclei-api.yml
+++ b/.github/workflows/fetch-nuclei-api.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api
 

--- a/.github/workflows/fetch-nuclei-api.yml
+++ b/.github/workflows/fetch-nuclei-api.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch nuclei-api --dir ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api ${{ secrets.NUCLEI_API_KEY }}
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-nuclei-api remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-nuclei-api

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -44,6 +44,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -58,9 +65,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 
@@ -72,14 +76,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.name "GitHub Action"
 
       # - name: Restore
       #   run: |

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -74,7 +74,7 @@ jobs:
       # - name: Fetch modified for last 3 days
       #   run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} --api-key ${{ secrets.NVD_API_KEY }} --concurrency 8 --wait 5s --last-mod-start-date $(git -C vuls-data-raw-${{ inputs.target }} log -1 --format='%ad' --date=format-local:'%Y-%m-%dT%H:%M:%S.000%z' | xargs -I{} date +'%Y-%m-%dT%T.%3N%:z' -d '{} -3 days') --last-mod-end-date $(date +'%Y-%m-%dT%T.%3N%:z')
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -40,6 +40,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -54,9 +61,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-paloalto-list
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-paloalto-list
 
@@ -68,14 +72,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} $(find ghcr.io/${{ github.repository }}/vuls-data-raw-paloalto-list -name "*.json" | xargs -I {} basename {} .json | tr '\n' ' ')
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-paloalto-list
         run: vuls-data-update dotgit pull --dir . --checkout main --restore ghcr.io/${{ github.repository }}:vuls-data-raw-paloalto-list
 

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -29,6 +29,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -43,9 +50,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
 
@@ -54,14 +58,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fetch all
         run: vuls-data-update fetch redhat-package-manifest --dir ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest 8 9 10
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-redhat-package-manifest remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-redhat-package-manifest
 

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} ${{ secrets.VARIOT_API_KEY }}
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -43,6 +43,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -57,9 +64,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 
@@ -68,14 +72,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -44,6 +44,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -58,9 +65,6 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
-
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 
@@ -69,14 +73,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config gc.auto 0
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           else
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
           fi
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.email "action@github.com"
-          git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Commit
         run: |

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install ./cmd/vuls-data-update
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}
 

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Fetch
         run: vuls-data-update fetch ${{ inputs.target }} --dir ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} ${{ secrets.VULNCHECK_API_KEY }}
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ghcr.io/${{ github.repository }}/vuls-data-raw-${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-${{ inputs.target }}

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -283,6 +283,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ inputs.repository }}:${{ inputs.tag }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ inputs.repository }}:${{ inputs.tag }}
 

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -274,6 +274,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -282,9 +289,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ inputs.repository }}:${{ inputs.tag }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ inputs.repository }}:${{ inputs.tag }}
@@ -295,7 +299,6 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ghcr.io/${{ inputs.repository }}/${{ inputs.tag }} config gc.auto 0
           git -C ghcr.io/${{ inputs.repository }}/${{ inputs.tag }} config pack.threads ${{ inputs.pack-threads }}
           git -C ghcr.io/${{ inputs.repository }}/${{ inputs.tag }} config pack.windowMemory ${{ inputs.pack-windowMemory }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Check out ${{ inputs.owner }}/${{ inputs.target }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -44,9 +51,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Check out ${{ inputs.owner }}/${{ inputs.target }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -58,14 +62,11 @@ jobs:
 
       - name: Set Git config
         run: |
-          git -C ${{ inputs.target }} config gc.auto 0
           if git -C ${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:${{ inputs.target }}
           else
             git -C ${{ inputs.target }} remote add origin ghcr.io/${{ github.repository }}:${{ inputs.target }}
           fi
-          git -C ${{ inputs.target }} config user.email "action@github.com"
-          git -C ${{ inputs.target }} config user.name "GitHub Action"
 
       - name: Create dotgit tarball
         run: vuls-data-update dotgit compress ${{ inputs.target }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
           path: ${{ inputs.target }}
           fetch-depth: "0"
 
-      - name: Set Git config
+      - name: Set Git remote
         run: |
           if git -C ${{ inputs.target }} remote | grep -q "^origin$"; then
             git -C ${{ inputs.target }} remote set-url origin ghcr.io/${{ github.repository }}:${{ inputs.target }}

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Truncate dotgit
         run: |
-          echo "Create the trucated repository..."
+          echo "Create the truncated repository..."
           git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
           git -C ${{ inputs.tag }} reset
           git -C ${{ inputs.tag }} branch nightly origin/nightly

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -124,6 +124,13 @@ jobs:
           remove-cached-tools: "true"
           remove-swapfile: "true"
 
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -132,9 +139,6 @@ jobs:
 
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-
-      - name: Disable git auto-gc globally
-        run: git config --global gc.auto 0
 
       - name: Pull ghcr.io/${{ github.repository }}:${{ inputs.tag }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:${{ inputs.tag }}
@@ -150,7 +154,7 @@ jobs:
       - name: Truncate dotgit
         run: |
           echo "Create the trucated repository..."
-          git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main --config gc.auto=0 file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
+          git clone --depth ${{ steps.decide_log_length.outputs.length }} --no-single-branch --no-checkout --branch main file://${PWD}/ghcr.io/${{ github.repository }}/${{ inputs.tag }} ${{ inputs.tag }}
           git -C ${{ inputs.tag }} reset
           git -C ${{ inputs.tag }} branch nightly origin/nightly
 

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Install vuls-data-update
         run: go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
 
+      - name: Disable git auto-gc globally
+        run: git config --global gc.auto 0
+
       - name: Pull ghcr.io/${{ github.repository }}:${{ inputs.tag }}
         run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:${{ inputs.tag }}
 


### PR DESCRIPTION
## Context

CI run [#25017235555](https://github.com/vulsio/vuls-data-db/actions/runs/25017235555/job/73269524763) (`extract-redhat-rhel-ovalv2.yml`, branch `nightly`) failed at the **Create dotgit tarball** step:

```
lstat ghcr.io/.../vuls-data-extracted-redhat-ovalv2-rhel/.git/objects/pack/tmp_pack_9MYDAD: no such file or directory
get info ghcr.io/.../vuls-data-extracted-redhat-ovalv2-rhel/.git/objects/pack/tmp_pack_9MYDAD
github.com/MaineK00n/vuls-data-update/pkg/dotgit/compress.options.compress.func1
        .../pkg/dotgit/compress/compress.go:112
...
failed to dotgit compress
```

`tmp_pack_XXXXXX` is the `mkstemp` template `git pack-objects` uses while writing a new pack. The walker in `dotgit compress` saw the entry during `readdir`, but by the time it called `lstat` the file had already been renamed/removed by `pack-objects` — i.e., a `git gc --auto` was running concurrently with the tarball walk.

## Root cause

Commit 7ea73c7 (_fix(ci/git): disable git gc auto before dotgit compress_) added per-repo `git -C <path> config gc.auto 0` before each compress. That writes to **local** `<repo>/.git/config` — but only **after** `dotgit pull` and `extract` have already run:

| step | order in `extract-redhat-rhel-ovalv2.yml` |
|------|--------------------------------------------|
| `dotgit pull` raw-redhat-ovalv2            | line 58 |
| `dotgit pull` raw-redhat-repository-to-cpe | line 69 |
| `dotgit pull` extracted-redhat-ovalv2-rhel | line 76 |
| Extract                                    | line 78 |
| **Set Git config** (sets local `gc.auto=0`)| line 81 |
| Commit                                     | line 92 |
| `dotgit compress` (← failed here)          | line 99 |

Anywhere from line 58 to line 90, a git command invoked transitively from `vuls-data-update` reads the **system default** `gc.auto=6700`, can trigger `git gc --auto`, and forks `pack-objects` to run in the background. The local `gc.auto=0` lands too late to suppress it. The background `pack-objects` then keeps writing/renaming `tmp_pack_*` for tens of seconds, racing with the later compress walk.

## Fix

Add a single early step that sets git config globally for the job, and remove every local/per-repo equivalent:

```yaml
- name: Set global git config
  run: |
    git config --global gc.auto 0
    git config --global init.defaultBranch main
    git config --global user.email "action@github.com"
    git config --global user.name "GitHub Action"
```

This step is placed **right after `Maximize build space`** (or as the very first step in `archive-epss.yml`, which has no `Maximize` step), so it precedes every git invocation in the job — including those inside `actions/checkout` and the early `vuls-data-update dotgit pull` calls. Once it has run, `gc.auto=0` is the system-visible default and `git gc --auto` becomes a no-op for the rest of the job.

The same step also takes over `init.defaultBranch`, `user.email`, and `user.name`, so the per-repo setters that used to handle them are no longer needed.

## What was removed

The single global step replaces all of the following per-repo / per-clone fallbacks across the same 27 workflows:

- `git -C <path> config gc.auto 0` (in every "Set Git config" step).
- `git -C <path> config user.email "action@github.com"`.
- `git -C <path> config user.name "GitHub Action"`.
- `git -c init.defaultBranch=main init .` flag (in `archive-epss.yml`).
- `git clone --config gc.auto=0` flag (in `archive.yml` and `truncate.yml`).

Per-repo `pack.threads` and `pack.windowMemory` in `gc.yml` are kept — they are operation-specific tunings, not redundant duplicates.

## Why not other approaches

- **Per-repo `gc.auto=0` only**: this was 7ea73c7 — fails because the local config is set too late.
- **Add a per-repo step right after each `dotgit pull`**: would need to be remembered for every new workflow and every new pull; one global setting is much harder to forget.
- **Make `dotgit compress` ignore `ENOENT` during walk**: unsafe. The race is not limited to `tmp_pack_*` — it also affects loose objects (deleted after they get repacked) and old pack files (deleted after consolidation). Silently skipping missing entries would produce a tarball with neither the loose object nor the new pack containing it → repository corruption that surfaces only when a downstream consumer tries to checkout. The current loud failure is the safer behavior; fix the source of concurrency, not the symptom.
- **`pgrep`-loop wait before compress**: band-aid; the race window is not strictly closed and `pack-objects` can re-spawn.
- **Upstream fix in `vuls-data-update`**: out of scope here.

## Affected files (27)

```
.github/workflows/archive-epss.yml
.github/workflows/archive.yml
.github/workflows/extract-eol.yml
.github/workflows/extract-main.yml
.github/workflows/extract-nvd-api-cve.yml
.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
.github/workflows/extract-redhat-rhel-ovalv1.yml
.github/workflows/extract-redhat-rhel-ovalv2.yml   ← failing one
.github/workflows/extract-redhat.yml
.github/workflows/fetch-cisco-cvrf-or-csaf.yml
.github/workflows/fetch-cisco-json.yml
.github/workflows/fetch-enisa-euvd-list.yml
.github/workflows/fetch-epss.yml
.github/workflows/fetch-fedora-api.yml
.github/workflows/fetch-fortinet-csaf.yml
.github/workflows/fetch-fortinet-cvrf.yml
.github/workflows/fetch-main.yml
.github/workflows/fetch-msuc.yml
.github/workflows/fetch-nuclei-api.yml
.github/workflows/fetch-nvd-api.yml
.github/workflows/fetch-paloalto-json-or-csaf.yml
.github/workflows/fetch-redhat-package-manifest.yml
.github/workflows/fetch-variot.yml
.github/workflows/fetch-vulncheck.yml
.github/workflows/gc.yml
.github/workflows/push.yml
.github/workflows/truncate.yml
```

## Test plan

- [ ] Re-run the failed job: `gh workflow run extract-redhat-rhel-ovalv2.yml -f branch=nightly` and confirm `Create dotgit tarball` succeeds.
- [ ] Wait for the next nightly auto-trigger to exercise the path with realistic loose-object counts.
- [ ] Spot-check another large-repo workflow (e.g. `extract-redhat-rhel-csaf-or-vex.yml`) for the same race.
- [ ] Static check after merge:
  ```bash
  # every dotgit-touching workflow has the global step
  grep -L 'Set global git config' $(grep -l 'vuls-data-update dotgit' .github/workflows/*.yml)
  # no per-repo gc.auto / user.email / user.name / init.defaultBranch=main / --config gc.auto= remains
  grep -nE 'config gc\.auto|config user\.|init\.defaultBranch=main|--config gc\.auto' .github/workflows/*.yml
  ```
  Both should print nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
