### PR TITLE
refactor(ci/diff-guard): defer rc to step outputs and aggregate at the end

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -351,9 +351,13 @@ runs:
           echo "| Diff vuls.db | ${rc_db_disp} | ${label_db} |"
         } >> "$GITHUB_STEP_SUMMARY"
 
-        # Map a recorded rc to the action's exit code: 0 stays 0, MISSING
-        # and non-numeric become 1, otherwise the rc is passed through
-        # (clamped to 1..255 to satisfy POSIX exit-code range).
+        # Map a recorded rc to the action's exit code: 0 stays 0, an
+        # rc in 1..255 is passed through (POSIX exit-code range), and
+        # everything else — empty (MISSING), non-numeric, or out of
+        # 1..255 — is mapped to 1. Out-of-range values are unreachable
+        # in practice (the shell already truncates child exit codes
+        # mod 256) so the catch-all 1 is a defensive "non-actionable
+        # rc → generic failure" rather than a numerical clamp.
         pick_exit() {
           local v="$1"
           case "$v" in

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -19,6 +19,14 @@ description: |
        failure is easier to interpret because the earlier detection checks
        already established detection stability.
 
+  Failure-handling strategy:
+    All three diff steps record their exit code as a step output (`rc`) and
+    continue rather than aborting the job. A final aggregation step reads
+    those outputs, prints a summary table, and fails the job if any check
+    tripped its threshold. This guarantees that one failing check does not
+    hide the signals from the others — when triage is needed the step
+    summary always contains all three diffs.
+
 inputs:
   target_db:
     description: Path to the freshly built vuls.db to validate.
@@ -105,6 +113,7 @@ runs:
         echo "- vulsio/integration @ \`${integration_sha}\`" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Diff detection between baseline and target DBs
+      id: diff_detection_master
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -122,9 +131,12 @@ runs:
         set -e
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff detection (vuls0 master HEAD)" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (vuls0 master HEAD) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
         head -n 100 ./diff-detection-report.md >> "$GITHUB_STEP_SUMMARY"
-        exit "$rc"
+        # Defer failure: final "Aggregate diff results" step exits non-zero
+        # if any diff tripped its threshold, so that all three diffs always
+        # run and their summaries are available for triage.
+        echo "rc=${rc}" >> "$GITHUB_OUTPUT"
 
     # Additional check with a slightly older vuls0 binary (pinned commit) to
     # catch regressions that only surface against past vuls0 versions.
@@ -165,6 +177,7 @@ runs:
         ls -1 ./scan-results-old
 
     - name: Diff detection with older vuls0 binary (baseline vs target DB)
+      id: diff_detection_old
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -183,11 +196,13 @@ runs:
         set -e
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7})" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7}) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
         head -n 100 ./diff-detection-old-report.md >> "$GITHUB_STEP_SUMMARY"
-        exit "$rc"
+        # Defer failure to "Aggregate diff results" step. See note above.
+        echo "rc=${rc}" >> "$GITHUB_OUTPUT"
 
     - name: Diff vuls.db against baseline
+      id: diff_db
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -202,6 +217,39 @@ runs:
         set -e
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff vuls.db" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff vuls.db — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
         head -n 300 ./diff-report.md >> "$GITHUB_STEP_SUMMARY"
-        exit "$rc"
+        # Defer failure to "Aggregate diff results" step. See note above.
+        echo "rc=${rc}" >> "$GITHUB_OUTPUT"
+
+    # Aggregate exit codes from all three diff steps. Each step above writes
+    # its rc to $GITHUB_OUTPUT without aborting, so by the time we reach this
+    # step every diff has run and the step summary already contains all three
+    # reports. We fail the job here if any check tripped its threshold so a
+    # single failure does not hide the information from the others.
+    - name: Aggregate diff results
+      shell: bash
+      env:
+        RC_DETECTION_MASTER: ${{ steps.diff_detection_master.outputs.rc }}
+        RC_DETECTION_OLD: ${{ steps.diff_detection_old.outputs.rc }}
+        RC_DB: ${{ steps.diff_db.outputs.rc }}
+      run: |
+        label_master="FAIL"; [ "${RC_DETECTION_MASTER}" = "0" ] && label_master="pass"
+        label_old="FAIL";    [ "${RC_DETECTION_OLD}"    = "0" ] && label_old="pass"
+        label_db="FAIL";     [ "${RC_DB}"               = "0" ] && label_db="pass"
+
+        {
+          echo "---"
+          echo "## Diff guard summary"
+          echo ""
+          echo "| Check | rc | Status |"
+          echo "| --- | --- | --- |"
+          echo "| Diff detection (vuls0 master HEAD) | ${RC_DETECTION_MASTER} | ${label_master} |"
+          echo "| Diff detection (older pinned vuls0) | ${RC_DETECTION_OLD} | ${label_old} |"
+          echo "| Diff vuls.db | ${RC_DB} | ${label_db} |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "${RC_DETECTION_MASTER}" != "0" ] || [ "${RC_DETECTION_OLD}" != "0" ] || [ "${RC_DB}" != "0" ]; then
+          echo "diff guard failed: detection(master)=${RC_DETECTION_MASTER} detection(old)=${RC_DETECTION_OLD} db=${RC_DB}" >&2
+          exit 1
+        fi

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -33,16 +33,17 @@ description: |
     abort the step before its `$GITHUB_OUTPUT` line is written. Reports
     are emitted via `if [ -s <file> ]; then head ...; else placeholder;`
     so a missing/empty report file is surfaced as a placeholder rather
-    than crashing the step. Each diff step (and the aggregation step)
-    additionally carries `if: ${{ success() || failure() }}` so an
-    upstream abort — including signal-kill or runner failure of an
-    earlier diff — does not skip the rest; downstream steps run,
-    capture their own rc, and the aggregator surfaces any genuinely
-    missing rc as MISSING. (`always()` would be the natural choice
-    here but it is rejected by the composite action manifest loader
-    when used on non-final steps; `success() || failure()` covers
-    every state except the cancelled one, which is also where we *do*
-    want to skip.)
+    than crashing the step. Each diff step additionally carries
+    `continue-on-error: true` so an upstream abort — including
+    signal-kill or runner failure of an earlier diff — does not skip
+    the rest; downstream steps still run via the default success()
+    gate (because `continue-on-error` re-maps a failure outcome to a
+    success-style conclusion), capture their own rc, and the
+    aggregator surfaces any genuinely missing rc as MISSING. The
+    aggregator itself runs under `if: ${{ always() }}` (accepted only
+    on the terminal step of a composite action) so it executes even
+    when an intermediate setup step — which has no `continue-on-error`
+    — fails outright.
 
     Exit-code policy: the aggregation step preserves the *first* non-zero
     rc in step order (master HEAD → older binary → diff db) as the
@@ -139,12 +140,20 @@ runs:
 
     - name: Diff detection between baseline and target DBs
       id: diff_detection_master
-      # Run regardless of upstream status so an early abort (e.g. an
-      # install/prepare step that died) cannot skip the diff step and
-      # silently leave its rc unrecorded. Each diff step is independent;
-      # paired with the `set +e` discipline below this guarantees the
-      # aggregator sees an rc — or a MISSING — for every diff.
-      if: ${{ success() || failure() }}
+      # `continue-on-error: true` lets the *next* step run even if this
+      # one is signal-killed or otherwise exits non-zero before
+      # recording its rc, by re-mapping a failure outcome to a
+      # success-style conclusion for the purposes of the default
+      # success()-gate on subsequent steps. Paired with the `set +e`
+      # discipline below this guarantees the aggregator sees an rc —
+      # or, if the step was killed before reaching the rc-write line,
+      # a MISSING — for every diff.
+      #
+      # `if: ${{ always() }}` would be the more idiomatic spelling but
+      # the composite-action manifest loader rejects status-check
+      # functions in `if:` on non-final steps. `continue-on-error` is
+      # a top-level step property and unaffected.
+      continue-on-error: true
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -218,7 +227,7 @@ runs:
     - name: Diff detection with older vuls0 binary (baseline vs target DB)
       id: diff_detection_old
       # See note on diff_detection_master.
-      if: ${{ success() || failure() }}
+      continue-on-error: true
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -249,7 +258,7 @@ runs:
     - name: Diff vuls.db against baseline
       id: diff_db
       # See note on diff_detection_master.
-      if: ${{ success() || failure() }}
+      continue-on-error: true
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -295,10 +304,15 @@ runs:
     - name: Aggregate diff results
       # Run unconditionally so a missing rc — caused by an upstream
       # diff step that aborted before recording its `$GITHUB_OUTPUT`
-      # line — still produces a summary table and a job-failing rc.
-      # In the normal path (each diff step stays in `set +e` and always
-      # writes its rc) this is a defense-in-depth guard.
-      if: ${{ success() || failure() }}
+      # line, or a setup step that failed entirely — still produces a
+      # summary table and a job-failing rc. `if: ${{ always() }}` is
+      # accepted on the *terminal* step of a composite action (it is
+      # rejected by the manifest loader when used on non-final steps,
+      # which is why the diff steps above use `continue-on-error`
+      # instead). Defense-in-depth: in the normal path each diff
+      # step stays in `set +e` and always writes its rc, so
+      # `continue-on-error` rarely fires.
+      if: ${{ always() }}
       shell: bash
       env:
         RC_DETECTION_MASTER: ${{ steps.diff_detection_master.outputs.rc }}

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -27,6 +27,16 @@ description: |
     hide the signals from the others — when triage is needed the step
     summary always contains all three diffs.
 
+    To make this guarantee robust, each diff step keeps `set +e` in
+    effect for the *entire* step (rather than re-enabling `set -e` after
+    capturing rc), so a stray failure on the summary-write path cannot
+    abort the step before its `$GITHUB_OUTPUT` line is written. Reports
+    are emitted via `if [ -s <file> ]; then head ...; else placeholder;`
+    so a missing/empty report file is surfaced as a placeholder rather
+    than crashing the step. As a defense-in-depth, the aggregation step
+    runs with `if: ${{ always() }}` so it executes even when an upstream
+    step abnormally exits.
+
     Exit-code policy: the aggregation step preserves the *first* non-zero
     rc in step order (master HEAD → older binary → diff db) as the
     action's exit code, matching the rc the old `exit "$rc"` design would
@@ -127,6 +137,11 @@ runs:
         TARGET_DB: ${{ inputs.target_db }}
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
       run: |
+        # Stay in `set +e` for the entire step. We must reach the final
+        # `echo "rc=..." >> $GITHUB_OUTPUT` regardless of what happens in
+        # between, so the aggregator can pick the rc up. A reinstated
+        # `set -e` would let an unrelated failure (e.g. a missing report
+        # file) abort the step before the rc is recorded.
         set +e
         set -o pipefail
         vuls diff detection \
@@ -136,11 +151,14 @@ runs:
           --change-rate-threshold "$DETECTION_CHANGE_RATE_THRESHOLD" \
           | tee ./diff-detection-report.md
         rc=$?
-        set -e
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff detection (vuls0 master HEAD) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
-        head -n 100 ./diff-detection-report.md >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (vuls0 master HEAD) — rc=${rc:-?}" >> "$GITHUB_STEP_SUMMARY"
+        if [ -s ./diff-detection-report.md ]; then
+          head -n 100 ./diff-detection-report.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "_(no report content — diff exited before producing output)_" >> "$GITHUB_STEP_SUMMARY"
+        fi
         # Defer failure: final "Aggregate diff results" step exits non-zero
         # if any diff tripped its threshold, so that all three diffs always
         # run and their summaries are available for triage.
@@ -192,6 +210,7 @@ runs:
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
         VULS0_OLD_REF: ${{ inputs.vuls0_old_ref }}
       run: |
+        # Stay in `set +e` for the entire step. See note above.
         set +e
         set -o pipefail
         vuls diff detection \
@@ -201,11 +220,14 @@ runs:
           --change-rate-threshold "$DETECTION_CHANGE_RATE_THRESHOLD" \
           | tee ./diff-detection-old-report.md
         rc=$?
-        set -e
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7}) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
-        head -n 100 ./diff-detection-old-report.md >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7}) — rc=${rc:-?}" >> "$GITHUB_STEP_SUMMARY"
+        if [ -s ./diff-detection-old-report.md ]; then
+          head -n 100 ./diff-detection-old-report.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "_(no report content — diff exited before producing output)_" >> "$GITHUB_STEP_SUMMARY"
+        fi
         # Defer failure to "Aggregate diff results" step. See note above.
         echo "rc=${rc}" >> "$GITHUB_OUTPUT"
 
@@ -216,17 +238,21 @@ runs:
         TARGET_DB: ${{ inputs.target_db }}
         DB_CHANGE_RATE_THRESHOLD: ${{ inputs.db_change_rate_threshold }}
       run: |
+        # Stay in `set +e` for the entire step. See note above.
         set +e
         set -o pipefail
         vuls diff db ./baseline.db "$TARGET_DB" \
           --change-rate-threshold "$DB_CHANGE_RATE_THRESHOLD" \
           | tee ./diff-report.md
         rc=$?
-        set -e
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff vuls.db — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
-        head -n 300 ./diff-report.md >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff vuls.db — rc=${rc:-?}" >> "$GITHUB_STEP_SUMMARY"
+        if [ -s ./diff-report.md ]; then
+          head -n 300 ./diff-report.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "_(no report content — diff exited before producing output)_" >> "$GITHUB_STEP_SUMMARY"
+        fi
         # Defer failure to "Aggregate diff results" step. See note above.
         echo "rc=${rc}" >> "$GITHUB_OUTPUT"
 
@@ -250,6 +276,12 @@ runs:
     # in the table and `?` in the diagnostic line, and treated as a
     # failure with rc=1 so the job still fails.
     - name: Aggregate diff results
+      # Run unconditionally so a missing rc — caused by an upstream
+      # diff step that aborted before recording its `$GITHUB_OUTPUT`
+      # line — still produces a summary table and a job-failing rc.
+      # In the normal path (each diff step stays in `set +e` and always
+      # writes its rc) this is a defense-in-depth guard.
+      if: ${{ always() }}
       shell: bash
       env:
         RC_DETECTION_MASTER: ${{ steps.diff_detection_master.outputs.rc }}

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -33,9 +33,11 @@ description: |
     abort the step before its `$GITHUB_OUTPUT` line is written. Reports
     are emitted via `if [ -s <file> ]; then head ...; else placeholder;`
     so a missing/empty report file is surfaced as a placeholder rather
-    than crashing the step. As a defense-in-depth, the aggregation step
-    runs with `if: ${{ always() }}` so it executes even when an upstream
-    step abnormally exits.
+    than crashing the step. Each diff step (and the aggregation step)
+    additionally carries `if: ${{ always() }}` so an upstream abort —
+    including signal-kill or runner failure of an earlier diff — does
+    not skip the rest; downstream steps run, capture their own rc, and
+    the aggregator surfaces any genuinely missing rc as MISSING.
 
     Exit-code policy: the aggregation step preserves the *first* non-zero
     rc in step order (master HEAD → older binary → diff db) as the
@@ -132,6 +134,12 @@ runs:
 
     - name: Diff detection between baseline and target DBs
       id: diff_detection_master
+      # Run regardless of upstream status so an early abort (e.g. an
+      # install/prepare step that died) cannot skip the diff step and
+      # silently leave its rc unrecorded. Each diff step is independent;
+      # paired with the `set +e` discipline below this guarantees the
+      # aggregator sees an rc — or a MISSING — for every diff.
+      if: ${{ always() }}
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -204,6 +212,8 @@ runs:
 
     - name: Diff detection with older vuls0 binary (baseline vs target DB)
       id: diff_detection_old
+      # See note on diff_detection_master.
+      if: ${{ always() }}
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -233,6 +243,8 @@ runs:
 
     - name: Diff vuls.db against baseline
       id: diff_db
+      # See note on diff_detection_master.
+      if: ${{ always() }}
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -27,6 +27,14 @@ description: |
     hide the signals from the others — when triage is needed the step
     summary always contains all three diffs.
 
+    Exit-code policy: the aggregation step preserves the *first* non-zero
+    rc in step order (master HEAD → older binary → diff db) as the
+    action's exit code, matching the rc the old `exit "$rc"` design would
+    have returned in both single- and multi-failure cases. A missing
+    output (the upstream step crashed before recording its rc) is
+    rendered as `MISSING` in the summary table, surfaced as `?` in the
+    diagnostic line, and counted as failure (exit rc=1).
+
 inputs:
   target_db:
     description: Path to the freshly built vuls.db to validate.
@@ -227,6 +235,20 @@ runs:
     # step every diff has run and the step summary already contains all three
     # reports. We fail the job here if any check tripped its threshold so a
     # single failure does not hide the information from the others.
+    #
+    # Exit-code policy: preserve the *first* non-zero rc in step order
+    # (master HEAD → older binary → diff db). Pre-refactor the action ran
+    # `exit "$rc"` from the first failing step and aborted, so the first
+    # failure's rc was the action's rc; by walking the same step order
+    # here we return the same rc the old design would have returned in
+    # both single- and multi-failure cases, keeping callers that branch
+    # on a specific rc fully compatible.
+    #
+    # MISSING rc: an empty `${RC_*}` means the upstream step crashed
+    # before writing its $GITHUB_OUTPUT line (e.g. an `set -e`-tripped
+    # error in surrounding non-`vuls` code). It is rendered as `MISSING`
+    # in the table and `?` in the diagnostic line, and treated as a
+    # failure with rc=1 so the job still fails.
     - name: Aggregate diff results
       shell: bash
       env:
@@ -234,9 +256,20 @@ runs:
         RC_DETECTION_OLD: ${{ steps.diff_detection_old.outputs.rc }}
         RC_DB: ${{ steps.diff_db.outputs.rc }}
       run: |
-        label_master="FAIL"; [ "${RC_DETECTION_MASTER}" = "0" ] && label_master="pass"
-        label_old="FAIL";    [ "${RC_DETECTION_OLD}"    = "0" ] && label_old="pass"
-        label_db="FAIL";     [ "${RC_DB}"               = "0" ] && label_db="pass"
+        status() {
+          case "$1" in
+            "")  echo "MISSING" ;;
+            "0") echo "PASS" ;;
+            *)   echo "FAIL" ;;
+          esac
+        }
+        label_master=$(status "${RC_DETECTION_MASTER}")
+        label_old=$(status "${RC_DETECTION_OLD}")
+        label_db=$(status "${RC_DB}")
+
+        rc_master_disp="${RC_DETECTION_MASTER:-?}"
+        rc_old_disp="${RC_DETECTION_OLD:-?}"
+        rc_db_disp="${RC_DB:-?}"
 
         {
           echo "---"
@@ -244,12 +277,37 @@ runs:
           echo ""
           echo "| Check | rc | Status |"
           echo "| --- | --- | --- |"
-          echo "| Diff detection (vuls0 master HEAD) | ${RC_DETECTION_MASTER} | ${label_master} |"
-          echo "| Diff detection (older pinned vuls0) | ${RC_DETECTION_OLD} | ${label_old} |"
-          echo "| Diff vuls.db | ${RC_DB} | ${label_db} |"
+          echo "| Diff detection (vuls0 master HEAD) | ${rc_master_disp} | ${label_master} |"
+          echo "| Diff detection (older pinned vuls0) | ${rc_old_disp} | ${label_old} |"
+          echo "| Diff vuls.db | ${rc_db_disp} | ${label_db} |"
         } >> "$GITHUB_STEP_SUMMARY"
 
-        if [ "${RC_DETECTION_MASTER}" != "0" ] || [ "${RC_DETECTION_OLD}" != "0" ] || [ "${RC_DB}" != "0" ]; then
-          echo "diff guard failed: detection(master)=${RC_DETECTION_MASTER} detection(old)=${RC_DETECTION_OLD} db=${RC_DB}" >&2
-          exit 1
+        # Map a recorded rc to the action's exit code: 0 stays 0, MISSING
+        # and non-numeric become 1, otherwise the rc is passed through
+        # (clamped to 1..255 to satisfy POSIX exit-code range).
+        pick_exit() {
+          local v="$1"
+          case "$v" in
+            "")        echo 1 ;;
+            *[!0-9]*)  echo 1 ;;
+            *)
+              if [ "$v" -ge 1 ] && [ "$v" -le 255 ]; then echo "$v"
+              elif [ "$v" = "0" ]; then echo 0
+              else echo 1
+              fi
+              ;;
+          esac
+        }
+
+        exit_rc=0
+        for rc in "${RC_DETECTION_MASTER}" "${RC_DETECTION_OLD}" "${RC_DB}"; do
+          if [ -z "$rc" ] || [ "$rc" != "0" ]; then
+            exit_rc=$(pick_exit "$rc")
+            break
+          fi
+        done
+
+        if [ "$exit_rc" != "0" ]; then
+          echo "diff guard failed: detection(master)=${rc_master_disp} detection(old)=${rc_old_disp} db=${rc_db_disp}" >&2
+          exit "$exit_rc"
         fi

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -34,16 +34,21 @@ description: |
     are emitted via `if [ -s <file> ]; then head ...; else placeholder;`
     so a missing/empty report file is surfaced as a placeholder rather
     than crashing the step. Each diff step additionally carries
-    `continue-on-error: true` so an upstream abort — including
-    signal-kill or runner failure of an earlier diff — does not skip
-    the rest; downstream steps still run via the default success()
-    gate (because `continue-on-error` re-maps a failure outcome to a
-    success-style conclusion), capture their own rc, and the
-    aggregator surfaces any genuinely missing rc as MISSING. The
-    aggregator itself runs under `if: ${{ always() }}` (accepted only
-    on the terminal step of a composite action) so it executes even
-    when an intermediate setup step — which has no `continue-on-error`
-    — fails outright.
+    `continue-on-error: true` so a signal-kill or other unexpected
+    abort of one diff step does not skip the rest; downstream steps
+    still run via the default success() gate (because
+    `continue-on-error` re-maps a failure outcome to a success-style
+    conclusion), capture their own rc, and the aggregator surfaces
+    any genuinely missing rc as MISSING.
+
+    (We would prefer to also wrap the aggregator in `if: always()` so
+    a failure in a non-`continue-on-error` setup step — install /
+    prepare-scan-results — would still produce a summary. But the
+    composite-action manifest loader switches to a legacy code path
+    once any step carries `continue-on-error`, and the legacy loader
+    rejects status-check function calls in `if:` even on the terminal
+    step. The trade-off is acceptable: setup-step failures are
+    genuine bugs the operator sees in the run UI directly anyway.)
 
     Exit-code policy: the aggregation step preserves the *first* non-zero
     rc in step order (master HEAD → older binary → diff db) as the
@@ -302,17 +307,18 @@ runs:
     # in the table and `?` in the diagnostic line, and treated as a
     # failure with rc=1 so the job still fails.
     - name: Aggregate diff results
-      # Run unconditionally so a missing rc — caused by an upstream
-      # diff step that aborted before recording its `$GITHUB_OUTPUT`
-      # line, or a setup step that failed entirely — still produces a
-      # summary table and a job-failing rc. `if: always()` is accepted
-      # on the *terminal* step of a composite action (it is rejected
-      # by the manifest loader when used on non-final steps, which is
-      # why the diff steps above use `continue-on-error` instead).
-      # Defense-in-depth: in the normal path each diff step stays in
-      # `set +e` and always writes its rc, so `continue-on-error`
-      # rarely fires.
-      if: ${{ always() }}
+      # No `if:` here: in the normal path each diff step stays in
+      # `set +e`, exits 0 (only the recorded rc is non-zero), and
+      # `continue-on-error: true` covers the residual signal-kill
+      # case — so all three diff steps are reported as success-style
+      # by the time we get here, and the default success() gate
+      # passes. The composite-action manifest loader rejects
+      # `if: always()` (and other status-check function calls) when
+      # *any* step in the action carries `continue-on-error`, so we
+      # cannot wear belt and suspenders here. Setup steps (install /
+      # prepare scan-results) without `continue-on-error` still gate
+      # this off if they fail outright, but those failures are real
+      # bugs the operator should see directly anyway.
       shell: bash
       env:
         RC_DETECTION_MASTER: ${{ steps.diff_detection_master.outputs.rc }}

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -325,15 +325,9 @@ runs:
           esac
         }
 
-        exit_rc=0
         for rc in "${RC_DETECTION_MASTER}" "${RC_DETECTION_OLD}" "${RC_DB}"; do
-          if [ -z "$rc" ] || [ "$rc" != "0" ]; then
-            exit_rc=$(pick_exit "$rc")
-            break
+          if [ "$rc" != "0" ]; then
+            echo "diff guard failed: detection(master)=${rc_master_disp} detection(old)=${rc_old_disp} db=${rc_db_disp}" >&2
+            exit "$(pick_exit "$rc")"
           fi
         done
-
-        if [ "$exit_rc" != "0" ]; then
-          echo "diff guard failed: detection(master)=${rc_master_disp} detection(old)=${rc_old_disp} db=${rc_db_disp}" >&2
-          exit "$exit_rc"
-        fi

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -34,10 +34,15 @@ description: |
     are emitted via `if [ -s <file> ]; then head ...; else placeholder;`
     so a missing/empty report file is surfaced as a placeholder rather
     than crashing the step. Each diff step (and the aggregation step)
-    additionally carries `if: ${{ always() }}` so an upstream abort —
-    including signal-kill or runner failure of an earlier diff — does
-    not skip the rest; downstream steps run, capture their own rc, and
-    the aggregator surfaces any genuinely missing rc as MISSING.
+    additionally carries `if: ${{ success() || failure() }}` so an
+    upstream abort — including signal-kill or runner failure of an
+    earlier diff — does not skip the rest; downstream steps run,
+    capture their own rc, and the aggregator surfaces any genuinely
+    missing rc as MISSING. (`always()` would be the natural choice
+    here but it is rejected by the composite action manifest loader
+    when used on non-final steps; `success() || failure()` covers
+    every state except the cancelled one, which is also where we *do*
+    want to skip.)
 
     Exit-code policy: the aggregation step preserves the *first* non-zero
     rc in step order (master HEAD → older binary → diff db) as the
@@ -139,7 +144,7 @@ runs:
       # silently leave its rc unrecorded. Each diff step is independent;
       # paired with the `set +e` discipline below this guarantees the
       # aggregator sees an rc — or a MISSING — for every diff.
-      if: ${{ always() }}
+      if: ${{ success() || failure() }}
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -213,7 +218,7 @@ runs:
     - name: Diff detection with older vuls0 binary (baseline vs target DB)
       id: diff_detection_old
       # See note on diff_detection_master.
-      if: ${{ always() }}
+      if: ${{ success() || failure() }}
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -244,7 +249,7 @@ runs:
     - name: Diff vuls.db against baseline
       id: diff_db
       # See note on diff_detection_master.
-      if: ${{ always() }}
+      if: ${{ success() || failure() }}
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
@@ -293,7 +298,7 @@ runs:
       # line — still produces a summary table and a job-failing rc.
       # In the normal path (each diff step stays in `set +e` and always
       # writes its rc) this is a defense-in-depth guard.
-      if: ${{ always() }}
+      if: ${{ success() || failure() }}
       shell: bash
       env:
         RC_DETECTION_MASTER: ${{ steps.diff_detection_master.outputs.rc }}

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -149,8 +149,8 @@ runs:
       # or, if the step was killed before reaching the rc-write line,
       # a MISSING — for every diff.
       #
-      # `if: ${{ always() }}` would be the more idiomatic spelling but
-      # the composite-action manifest loader rejects status-check
+      # `if: always()` would be the more idiomatic spelling but the
+      # composite-action manifest loader rejects status-check
       # functions in `if:` on non-final steps. `continue-on-error` is
       # a top-level step property and unaffected.
       continue-on-error: true
@@ -305,13 +305,13 @@ runs:
       # Run unconditionally so a missing rc — caused by an upstream
       # diff step that aborted before recording its `$GITHUB_OUTPUT`
       # line, or a setup step that failed entirely — still produces a
-      # summary table and a job-failing rc. `if: ${{ always() }}` is
-      # accepted on the *terminal* step of a composite action (it is
-      # rejected by the manifest loader when used on non-final steps,
-      # which is why the diff steps above use `continue-on-error`
-      # instead). Defense-in-depth: in the normal path each diff
-      # step stays in `set +e` and always writes its rc, so
-      # `continue-on-error` rarely fires.
+      # summary table and a job-failing rc. `if: always()` is accepted
+      # on the *terminal* step of a composite action (it is rejected
+      # by the manifest loader when used on non-final steps, which is
+      # why the diff steps above use `continue-on-error` instead).
+      # Defense-in-depth: in the normal path each diff step stays in
+      # `set +e` and always writes its rc, so `continue-on-error`
+      # rarely fires.
       if: ${{ always() }}
       shell: bash
       env:

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -145,30 +145,18 @@ runs:
 
     - name: Diff detection between baseline and target DBs
       id: diff_detection_master
-      # `continue-on-error: true` lets the *next* step run even if this
-      # one is signal-killed or otherwise exits non-zero before
-      # recording its rc, by re-mapping a failure outcome to a
-      # success-style conclusion for the purposes of the default
-      # success()-gate on subsequent steps. Paired with the `set +e`
-      # discipline below this guarantees the aggregator sees an rc —
-      # or, if the step was killed before reaching the rc-write line,
-      # a MISSING — for every diff.
-      #
-      # `if: always()` would be the more idiomatic spelling but the
-      # composite-action manifest loader rejects status-check
-      # functions in `if:` on non-final steps. `continue-on-error` is
-      # a top-level step property and unaffected.
+      # See the `Failure-handling strategy` section in the action's
+      # description for why this is `continue-on-error: true` rather
+      # than `if: always()`.
       continue-on-error: true
       shell: bash
       env:
         TARGET_DB: ${{ inputs.target_db }}
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
       run: |
-        # Stay in `set +e` for the entire step. We must reach the final
-        # `echo "rc=..." >> $GITHUB_OUTPUT` regardless of what happens in
-        # between, so the aggregator can pick the rc up. A reinstated
-        # `set -e` would let an unrelated failure (e.g. a missing report
-        # file) abort the step before the rc is recorded.
+        # No `set -e` after `rc=$?` — the rest of the step must reach
+        # the final `echo "rc=..." >> $GITHUB_OUTPUT` so the aggregator
+        # can read it.
         set +e
         set -o pipefail
         vuls diff detection \
@@ -180,7 +168,7 @@ runs:
         rc=$?
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff detection (vuls0 master HEAD) — rc=${rc:-?}" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (vuls0 master HEAD) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
         if [ -s ./diff-detection-report.md ]; then
           head -n 100 ./diff-detection-report.md >> "$GITHUB_STEP_SUMMARY"
         else
@@ -251,7 +239,7 @@ runs:
         rc=$?
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7}) — rc=${rc:-?}" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7}) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
         if [ -s ./diff-detection-old-report.md ]; then
           head -n 100 ./diff-detection-old-report.md >> "$GITHUB_STEP_SUMMARY"
         else
@@ -278,7 +266,7 @@ runs:
         rc=$?
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
-        echo "## Diff vuls.db — rc=${rc:-?}" >> "$GITHUB_STEP_SUMMARY"
+        echo "## Diff vuls.db — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
         if [ -s ./diff-report.md ]; then
           head -n 300 ./diff-report.md >> "$GITHUB_STEP_SUMMARY"
         else
@@ -287,38 +275,12 @@ runs:
         # Defer failure to "Aggregate diff results" step. See note above.
         echo "rc=${rc}" >> "$GITHUB_OUTPUT"
 
-    # Aggregate exit codes from all three diff steps. Each step above writes
-    # its rc to $GITHUB_OUTPUT without aborting, so by the time we reach this
-    # step every diff has run and the step summary already contains all three
-    # reports. We fail the job here if any check tripped its threshold so a
-    # single failure does not hide the information from the others.
-    #
-    # Exit-code policy: preserve the *first* non-zero rc in step order
-    # (master HEAD → older binary → diff db). Pre-refactor the action ran
-    # `exit "$rc"` from the first failing step and aborted, so the first
-    # failure's rc was the action's rc; by walking the same step order
-    # here we return the same rc the old design would have returned in
-    # both single- and multi-failure cases, keeping callers that branch
-    # on a specific rc fully compatible.
-    #
-    # MISSING rc: an empty `${RC_*}` means the upstream step crashed
-    # before writing its $GITHUB_OUTPUT line (e.g. an `set -e`-tripped
-    # error in surrounding non-`vuls` code). It is rendered as `MISSING`
-    # in the table and `?` in the diagnostic line, and treated as a
-    # failure with rc=1 so the job still fails.
+    # See the action description for the full Failure-handling and
+    # Exit-code policy. In short: every diff step has run by now and
+    # written its rc (or left it MISSING if killed before recording).
+    # This step turns the three rc values into a summary table and a
+    # single exit code (first non-zero in step order).
     - name: Aggregate diff results
-      # No `if:` here: in the normal path each diff step stays in
-      # `set +e`, exits 0 (only the recorded rc is non-zero), and
-      # `continue-on-error: true` covers the residual signal-kill
-      # case — so all three diff steps are reported as success-style
-      # by the time we get here, and the default success() gate
-      # passes. The composite-action manifest loader rejects
-      # `if: always()` (and other status-check function calls) when
-      # *any* step in the action carries `continue-on-error`, so we
-      # cannot wear belt and suspenders here. Setup steps (install /
-      # prepare scan-results) without `continue-on-error` still gate
-      # this off if they fail outright, but those failures are real
-      # bugs the operator should see directly anyway.
       shell: bash
       env:
         RC_DETECTION_MASTER: ${{ steps.diff_detection_master.outputs.rc }}
@@ -351,24 +313,15 @@ runs:
           echo "| Diff vuls.db | ${rc_db_disp} | ${label_db} |"
         } >> "$GITHUB_STEP_SUMMARY"
 
-        # Map a recorded rc to the action's exit code: 0 stays 0, an
-        # rc in 1..255 is passed through (POSIX exit-code range), and
-        # everything else — empty (MISSING), non-numeric, or out of
-        # 1..255 — is mapped to 1. Out-of-range values are unreachable
-        # in practice (the shell already truncates child exit codes
-        # mod 256) so the catch-all 1 is a defensive "non-actionable
-        # rc → generic failure" rather than a numerical clamp.
+        # Map a non-zero recorded rc to the action's exit code:
+        # numeric 1..255 → pass through, anything else (empty MISSING,
+        # non-numeric, > 255) → 1. The caller's loop only invokes this
+        # for empty or non-zero rc, so 0 is unreachable here.
         pick_exit() {
           local v="$1"
           case "$v" in
-            "")        echo 1 ;;
-            *[!0-9]*)  echo 1 ;;
-            *)
-              if [ "$v" -ge 1 ] && [ "$v" -le 255 ]; then echo "$v"
-              elif [ "$v" = "0" ]; then echo 0
-              else echo 1
-              fi
-              ;;
+            "" | *[!0-9]*) echo 1 ;;
+            *) [ "$v" -le 255 ] && echo "$v" || echo 1 ;;
           esac
         }
 


### PR DESCRIPTION
## Summary

Each of the three diff steps in [.github/actions/diff-guard/action.yml](.github/actions/diff-guard/action.yml) — `vuls diff detection` against vuls0 master HEAD, against the pinned older vuls0, and `vuls diff db` — used to abort the composite action with `exit "$rc"` on the first non-zero rc. A single failing check hid the other two checks' output; operators triaging a guard failure had to re-run with one or more checks disabled to see the full picture.

This PR reshapes the composite so every diff step always reaches the end and contributes to a single aggregated decision.

**Per diff step**:
- Stays in `set +e` for the entire step (no re-enable after capturing `rc`), so a stray failure on the summary-write path cannot abort the step before recording rc.
- Writes its rc to `$GITHUB_OUTPUT` (`steps.<id>.outputs.rc`), then exits 0.
- `head` is guarded by `[ -s <report> ]`; an absent or empty report renders a placeholder line in the step summary instead of crashing the step.
- Carries `continue-on-error: true` so a signal-kill or runner abort does not skip the remaining diff steps.

**Aggregator** (final step):
- Reads all three step outputs.
- Prints a `Diff guard summary` table with PASS / FAIL / MISSING (consistent casing) per check.
- Exits with the *first* non-zero rc in step order (master HEAD → older binary → diff db). This matches the rc the old `exit "$rc"` design returned in both single- and multi-failure cases — callers branching on a specific rc remain compatible. Out-of-range / non-numeric / MISSING all collapse to 1.

The refactor lives entirely inside the composite action — caller workflows (`db-main.yml`, `db-nightly.yml`) are unchanged.

### Notable composite-action quirk
`continue-on-error: true` on any step switches the composite to `ActionManifestManagerLegacy`, which then rejects status-check function calls (`always()`, `success()`, `failure()`) in `if:` everywhere — including the terminal step. We therefore cannot wear belt-and-suspenders with `if: ${{ always() }}` on the aggregator. Instead, the `set +e` discipline ensures every diff step exits 0 (rc is recorded, not re-thrown), so the aggregator's default `success()` gate passes regardless of diff outcomes. The only residual case left uncovered is a non-`continue-on-error` setup step (install / prepare-scan-results) failing outright, which is a genuine bug visible in the run UI directly.

## Test plan

- [x] `actionlint` (+ `shellcheck` integration) on `db-main.yml` / `db-nightly.yml`: 0 errors related to this change.
- [x] `shellcheck` on the extracted aggregator bash and the extracted post-rc-capture bash from each diff step: clean.
- [x] **15-case parametric local test** of the aggregator logic — all-pass, every single-FAIL position, every double-FAIL pair, all-FAIL, exit-code preservation (e.g. `rc=42 → exit 42`), step-order priority on multi-FAIL, out-of-range / non-numeric → 1, MISSING in each position. All cases pass.
- [x] **4-case parametric local test** of the post-rc-capture path — rc=0 / report present, rc=1 / report present, rc=1 / report missing → placeholder, rc=1 / report empty → placeholder. All cases pass.
- [x] **End-to-end on `shino/sandbox`** with four workflows reusing the same composite action via `uses: ./.github/actions/diff-guard`:
  - **Happy path** (current nightly DB as both baseline and target) → rc=(0,0,0), `Diff guard summary` shows `PASS / PASS / PASS`, job success, Promote step runs.
  - **Partial failure — redhat diff-db** (pinned 2026-03-03/04 historical DBs, ~65% redhat:6 churn) → rc=(1,0,1), summary shows `FAIL / PASS / FAIL`, exit 1, Promote skipped. Demonstrates one diff failure does not hide the others.
  - **Partial failure — ubuntu detection** (pinned 2026-03-10/11 historical DBs, ~745% ubuntu:25.10 churn) → rc=(0,1,0), summary shows `PASS / FAIL / PASS`, exit 1, Promote skipped. Mirror image of the above.
  - **Synthetic MISSING via SIGKILL** (a `vuls` saboteur installed on PATH SIGKILLs the bash shell only when invoked with `./scan-results-old`, exclusively matching the older-binary detection step) → rc=(0,?,0), summary shows `PASS / MISSING / PASS`, aggregator stderr `diff guard failed: detection(master)=0 detection(old)=? db=0`, exit 1, Promote skipped. **Confirms that even the most adversarial abort path — signal-kill mid-step before the rc-record line — does not skip the remaining diff steps and is correctly surfaced as MISSING by the aggregator.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)