### PR TITLE
chore(ci): scope permissions per job with empty workflow defaults

### DIFF
--- a/.github/workflows/action-run-summary.yml
+++ b/.github/workflows/action-run-summary.yml
@@ -9,14 +9,14 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   report:
     name: Action run summary
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     steps:
       - name: Collect action run summary
         env:

--- a/.github/workflows/archive-epss.yml
+++ b/.github/workflows/archive-epss.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   archive:

--- a/.github/workflows/archive-raw.yml
+++ b/.github/workflows/archive-raw.yml
@@ -7,8 +7,7 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   archive-raw:

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -193,8 +193,7 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
+permissions: {}
 
 defaults:
   run:

--- a/.github/workflows/backup-daily.yml
+++ b/.github/workflows/backup-daily.yml
@@ -5,8 +5,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backup:

--- a/.github/workflows/backup-monthly.yml
+++ b/.github/workflows/backup-monthly.yml
@@ -5,8 +5,7 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backup:

--- a/.github/workflows/backup-weekly.yml
+++ b/.github/workflows/backup-weekly.yml
@@ -5,8 +5,7 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backup:

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -46,8 +46,7 @@ on:
           - backup-weekly
           - backup-monthly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backup:

--- a/.github/workflows/check-layer-size.yml
+++ b/.github/workflows/check-layer-size.yml
@@ -39,8 +39,7 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:

--- a/.github/workflows/cleanup-vuls-data-db-archive.yml
+++ b/.github/workflows/cleanup-vuls-data-db-archive.yml
@@ -7,8 +7,7 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup-vuls-data-db-backup.yml
+++ b/.github/workflows/cleanup-vuls-data-db-backup.yml
@@ -7,8 +7,7 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup-vuls-data-db.yml
+++ b/.github/workflows/cleanup-vuls-data-db.yml
@@ -8,8 +8,7 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,8 +17,7 @@ on:
           - vuls-data-db-archive
           - vuls-data-db-backup
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   cleanup:

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -14,8 +14,7 @@ on:
         required: false
         default: "5"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -14,8 +14,7 @@ on:
         required: false
         default: "5"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/extract-all.yml
+++ b/.github/workflows/extract-all.yml
@@ -13,8 +13,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract-main:

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -15,8 +15,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -138,8 +138,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -15,8 +15,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -24,8 +24,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/extract-redhat-rhel-ovalv1.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv1.yml
@@ -15,8 +15,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/extract-redhat-rhel-ovalv2.yml
+++ b/.github/workflows/extract-redhat-rhel-ovalv2.yml
@@ -15,8 +15,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -26,8 +26,7 @@ on:
           - main
           - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   extract:

--- a/.github/workflows/fetch-all.yml
+++ b/.github/workflows/fetch-all.yml
@@ -11,8 +11,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch-main:

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -15,8 +15,7 @@ on:
           - cisco-cvrf
           - cisco-csaf
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -9,8 +9,7 @@ on:
         required: true
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -10,8 +10,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-fedora-api.yml
+++ b/.github/workflows/fetch-fedora-api.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fedora-release:

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -10,8 +10,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -10,8 +10,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -155,8 +155,7 @@ on:
           - wolfi-secdb
           - wrlinux
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   list-names:

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -10,6 +10,8 @@ jobs:
   list-names:
     name: List MSUC target names
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       include: ${{ steps.list.outputs.include }}
     steps:

--- a/.github/workflows/fetch-nuclei-api.yml
+++ b/.github/workflows/fetch-nuclei-api.yml
@@ -7,8 +7,7 @@ on:
         required: true
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -19,8 +19,7 @@ on:
           - nvd-api-cpe
           - nvd-api-cpematch
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -15,8 +15,7 @@ on:
           - paloalto-json
           - paloalto-csaf
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -18,8 +18,7 @@ on:
           - variot-exploits
           - variot-vulns
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -19,8 +19,7 @@ on:
           - vulncheck-nist-nvd
           - vulncheck-nist-nvd2
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fetch:

--- a/.github/workflows/gc-extracted.yml
+++ b/.github/workflows/gc-extracted.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   gc:

--- a/.github/workflows/gc-raw.yml
+++ b/.github/workflows/gc-raw.yml
@@ -4,8 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   gc:

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -249,8 +249,7 @@ on:
         default: 4g
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   gc:

--- a/.github/workflows/promote-digest.yml
+++ b/.github/workflows/promote-digest.yml
@@ -29,8 +29,7 @@ on:
           - nightly
           - "0"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   promote:

--- a/.github/workflows/restore-all.yml
+++ b/.github/workflows/restore-all.yml
@@ -13,8 +13,7 @@ on:
           - backup-weekly
           - backup-monthly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   restore-all:

--- a/.github/workflows/restore.yml
+++ b/.github/workflows/restore.yml
@@ -31,8 +31,7 @@ on:
           - backup-weekly
           - backup-monthly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   restore:

--- a/.github/workflows/truncate-extracted.yml
+++ b/.github/workflows/truncate-extracted.yml
@@ -7,8 +7,7 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   truncate-extracted:

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -60,8 +60,7 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
+permissions: {}
 
 defaults:
   run:


### PR DESCRIPTION
Set workflow-level permissions to {} across all workflows and grant only the minimum required permissions at each job. action-run-summary now requests actions: read at the report job (no checkout needed); check-layer-size inherits empty permissions since it only queries public ghcr metadata.