### PR TITLE
fix(ci): disable maintenance.auto to stop tmp_pack race on git 2.54

### DIFF
--- a/.github/workflows/archive-epss.yml
+++ b/.github/workflows/archive-epss.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -262,6 +262,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -165,6 +165,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-nvd-api-cve.yml
+++ b/.github/workflows/extract-nvd-api-cve.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-redhat-rhel-oval-v1.yml
+++ b/.github/workflows/extract-redhat-rhel-oval-v1.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-redhat-rhel-oval-v2.yml
+++ b/.github/workflows/extract-redhat-rhel-oval-v2.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-fedora-api.yml
+++ b/.github/workflows/fetch-fedora-api.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -183,6 +183,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-nuclei-api.yml
+++ b/.github/workflows/fetch-nuclei-api.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -279,6 +279,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/initialize.yml
+++ b/.github/workflows/initialize.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Set global git config
         run: |
           git config --global gc.auto 0
+          git config --global maintenance.auto false
           git config --global init.defaultBranch main
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"


### PR DESCRIPTION
## Summary

`Create dotgit tarball` (`vuls-data-update dotgit compress`) has been failing
intermittently across many fetch/extract jobs since **2026-05-15** with:

```
lstat .../.git/objects/pack/tmp_pack_XXXXXX: no such file or directory
```

This is a background `git pack-objects` racing the `dotgit compress` directory
walk. Root cause: **git 2.54 changed the default `git maintenance` strategy, so
`gc.auto=0` no longer disables the background packing that `git commit`
triggers.**

This PR adds `git config --global maintenance.auto false` to the
`Set global git config` step in every workflow that runs `dotgit compress`
(27 files).

## Root cause

#143 set `gc.auto=0` globally to stop `git commit`'s end-of-command
auto-maintenance from spawning a background `git gc` that races
`dotgit compress`. That worked — until the GitHub-hosted runners upgraded git
**2.53 → 2.54**.

git 2.54 changed the default strategy for *unscheduled* `git maintenance` from
`gc` to `geometric` (`builtin/gc.c`, `initialize_task_config()`):

```c
// v2.53.0
} else {
    strategy = gc_strategy;        // unscheduled -> gc task
}
// v2.54.0
} else {
    strategy = geometric_strategy; // unscheduled -> geometric-repack task (no gc task)
    type = MAINTENANCE_TYPE_MANUAL;
}
```

`git commit` runs `git maintenance run --auto` at the end of every commit (this
is "unscheduled" maintenance). On git 2.54 that now runs the **`geometric-repack`**
task (`git repack --geometric`) instead of the **`gc`** task.

- `gc.auto=0` only gates the **`gc`** task.
- It does **not** gate `geometric-repack` — that task is governed by
  `maintenance.geometric-repack.*`, not `gc.auto`.

So on git 2.54, every `git commit` on a dotgit repo (e.g. the `Commit` step in
extract/fetch) spawns a detached background `pack-objects`, which writes
`.git/objects/pack/tmp_pack_*` and races the subsequent `dotgit compress` step.

## Evidence

**Timeline** — runner git version vs. `Create dotgit tarball` failures:

| Date | Runner git | `Create dotgit tarball` failures |
|---|---|---|
| 05-06 .. 05-14 | 2.53.0 (observed 05-13) | **0** |
| 05-15 | (2.54 rollout) | 11 |
| 05-16 / 17 / 18 / 19 / 20 | 2.54.0 (observed) | 7 / 11 / 9 / 13 / 5 |

Failures begin **exactly** when the runner image moved to git 2.54.

**Local reproduction** (git 2.53): with global `gc.auto=0`, `git commit` on a
repo with 7000+ loose objects spawns no background gc; with `gc.auto` unset it
does. → confirms `gc.auto=0` was genuinely effective on git ≤2.53, and the
regression is the 2.54 strategy change — not a global-vs-local config issue.

## Affected repositories — not redhat-only

In the last 2 weeks: **56 failed `Create dotgit tarball` jobs across 16 targets**,
on both `raw` (fetch) and `extracted` (extract) dotgits.

- High frequency: `redhat-csaf` (×20), `fedora-api` (×10), `suse-oval` (×8),
  `wolfi-secdb` (×5)
- Also: `redhat-vex-v1`, `redhat-cve`, `nvd-api-cve`,
  `debian-security-tracker-api`, `debian-security-tracker-salsa`, `npm-osv`,
  `cargo-osv`, `photon-oval`, `pip-glsa`, `ubuntu-cve-tracker`,
  `vulncheck-nist-nvd`, `echo-data`

It is a fleet-wide probabilistic race — repos whose background `pack-objects`
runs long enough to still be active during `compress` (i.e. larger repos) lose
the race most often.

## The fix

Add one line to the `Set global git config` step:

```yaml
git config --global gc.auto 0
git config --global maintenance.auto false   # <- added
...
```

`maintenance.auto=false` makes porcelain commands (`git commit`, …) skip
`git maintenance run --auto` entirely — the version-proof off switch, independent
of which strategy/tasks are default.

`gc.auto 0` is kept as-is: harmless, and still relevant for older git.

Notes:

- `maintenance.strategy=none` is **not** a valid alternative — git 2.54's
  `parse_maintenance_strategy()` accepts only `incremental`/`gc`/`geometric` and
  `die()`s on anything else.
- Applied to all 27 workflows that run `dotgit compress` (verified: that set is
  exactly the set that already had `gc.auto 0` — no gaps).

## Out of scope

- `gc.yml`'s explicit `git gc --aggressive --force` is **not** affected — it is a
  foreground, non-`--auto` gc that completes before `compress`, and `gc.yml` runs
  no `git commit`. (The `maintenance.auto false` line added there is harmless
  consistency.)
- Hardening `vuls-data-update`'s `dotgit compress` to fail loudly on a detected
  concurrent writer is a separate change in the `vuls-data-update` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
