### PR TITLE
chore(ci/db-nightly): seed diff-guard threshold overrides

### DIFF
--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -16,8 +16,11 @@ on:
           multi-line "<ecosystem>=<rate>" entries. Leave empty to use the
           persistent list in the build job's
           DB_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty value here
-          replaces it for this dispatch only. Blank/whitespace-only lines
-          are dropped; per-entry whitespace is trimmed by vuls2.
+          replaces it for this dispatch only. A whitespace-only value
+          still counts as non-empty, so it replaces the env list with
+          nothing — use it to disable all persistent overrides for a
+          single dispatch. Blank/whitespace-only lines are dropped;
+          per-entry whitespace is trimmed by vuls2.
         required: false
         type: string
         default: ""
@@ -32,7 +35,10 @@ on:
           threshold, as multi-line "<file-basename>=<rate>" entries.
           Leave empty to use the persistent list in the build job's
           DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
-          value here replaces it for this dispatch only.
+          value here replaces it for this dispatch only. A
+          whitespace-only value still counts as non-empty, so it
+          replaces the env list with nothing — use it to disable all
+          persistent overrides for a single dispatch.
           Blank/whitespace-only lines are dropped; per-entry whitespace
           is trimmed by vuls2.
         required: false
@@ -57,9 +63,10 @@ jobs:
       # values whenever no dispatch input is supplied. Each entry covers
       # recurring upstream-driven churn (new-distro / rolling-release /
       # monthly vendor-data cycles) found in a review of db-nightly
-      # failures over 2026-04-30..05-20; see PR #152 for the per-entry
-      # failure-rate rationale. `#` comments are NOT allowed inside these
-      # lists (vuls2's override parser would reject them).
+      # failures over 2026-04-30..05-20; run `git blame` on these lines
+      # for the commit that introduced each entry and its rationale.
+      # `#` comments are NOT allowed inside these lists (vuls2's override
+      # parser would reject them).
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
         microsoft=35

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -12,28 +12,15 @@ on:
         default: "10"
       db_change_rate_threshold_overrides:
         description: |
-          Per-ecosystem overrides of `vuls diff db` threshold. One
-          "<ecosystem>=<rate>" entry per line (e.g. "ubuntu:26.04=25").
-          Blank/whitespace-only lines are dropped. Leading/trailing
-          whitespace around an entry's key and value is not trimmed
-          here — vuls2's override parser trims both sides, so it has no
-          effect on the resolved override. Persistent overrides should
-          be added to this default in a PR (with rationale in the PR
-          description) rather than at dispatch.
+          Per-ecosystem overrides of `vuls diff db` threshold, as
+          multi-line "<ecosystem>=<rate>" entries. Leave empty to use the
+          persistent list in the build job's
+          DB_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty value here
+          replaces it for this dispatch only. Blank/whitespace-only lines
+          are dropped; per-entry whitespace is trimmed by vuls2.
         required: false
         type: string
-        # Persistent per-ecosystem overrides. Each entry is justified by
-        # recurring upstream-driven churn seen in db-nightly failures over
-        # the 2026-04-30..05-20 review window:
-        #   ubuntu:26.04=30 — Ubuntu 26.04 (future release): new-distro
-        #                     structural churn; observed ~17% db drift.
-        #   microsoft=35    — Microsoft KB bucket churns on the monthly
-        #                     Patch Tuesday cycle; observed KB rate 15-28%.
-        #   fedora:45=50    — Fedora 45 (recent release): observed ~39% drift.
-        default: |
-          ubuntu:26.04=30
-          microsoft=35
-          fedora:45=50
+        default: ""
       detection_change_rate_threshold:
         description: "`vuls diff detection` default change rate (%) threshold per scan result; diff fails if exceeded"
         required: false
@@ -41,28 +28,16 @@ on:
         default: "5"
       detection_change_rate_threshold_overrides:
         description: |
-          Per-scan-result-file overrides of `vuls diff detection` threshold.
-          One "<file-basename>=<rate>" entry per line (e.g. "debian_13=8").
-          Blank/whitespace-only lines are dropped. Leading/trailing
-          whitespace around an entry's key and value is not trimmed
-          here — vuls2's override parser trims both sides, so it has no
-          effect on the resolved override. Persistent overrides should
-          be added to this default in a PR.
+          Per-scan-result-file overrides of `vuls diff detection`
+          threshold, as multi-line "<file-basename>=<rate>" entries.
+          Leave empty to use the persistent list in the build job's
+          DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
+          value here replaces it for this dispatch only.
+          Blank/whitespace-only lines are dropped; per-entry whitespace
+          is trimmed by vuls2.
         required: false
         type: string
-        # Persistent per-file overrides. Each entry is justified by
-        # recurring upstream-driven churn seen in db-nightly failures over
-        # the 2026-04-30..05-20 review window:
-        #   debian_13=20           — Debian 13 (trixie): steady new-CVE
-        #                            inflow from the upstream feed; 5-14% drift.
-        #   ubuntu_2604=50         — Ubuntu 26.04 (future release):
-        #                            new-distro churn; observed 9-39% drift.
-        #   opensuse_tumbleweed=15 — rolling release, churns by design;
-        #                            observed ~7% drift.
-        default: |
-          debian_13=20
-          ubuntu_2604=50
-          opensuse_tumbleweed=15
+        default: ""
 
 permissions: {}
 
@@ -75,6 +50,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOEXPERIMENT: jsonv2
+      # Persistent diff-guard threshold overrides — the single source of
+      # truth, applied to BOTH scheduled and manually-dispatched runs.
+      # workflow_dispatch input defaults are NOT visible to `schedule`
+      # events, so the `Run diff guard` step falls back to these env
+      # values whenever no dispatch input is supplied. Each entry covers
+      # recurring upstream-driven churn (new-distro / rolling-release /
+      # monthly vendor-data cycles) found in a review of db-nightly
+      # failures over 2026-04-30..05-20; see PR #152 for the per-entry
+      # failure-rate rationale. `#` comments are NOT allowed inside these
+      # lists (vuls2's override parser would reject them).
+      DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
+        ubuntu:26.04=30
+        microsoft=35
+        fedora:45=50
+      DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
+        debian_13=20
+        ubuntu_2604=50
+        opensuse_tumbleweed=15
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
@@ -134,20 +127,21 @@ jobs:
 
       # Runs on every scheduled and manually dispatched invocation.
       - name: Run diff guard
-        # On scheduled runs, github.event.inputs.* is typically unset/null
-        # rather than an empty string. The `|| 'default'` fallbacks below
-        # let this workflow run without workflow_dispatch inputs.
-        # The `_overrides` inputs default to an empty string when unset;
-        # the composite action drops blank/whitespace-only lines and an
-        # empty result is parsed by vuls2 as "no overrides".
+        # On scheduled runs github.event.inputs.* is unset/null, so the
+        # `|| ...` fallbacks supply the values. Thresholds fall back to
+        # literals; the `_overrides` fall back to the job-level env lists
+        # (DB/DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES) so the persistent
+        # overrides apply to scheduled runs too. A workflow_dispatch
+        # `_overrides` input, when supplied, replaces the env list for
+        # that run.
         uses: ./.github/actions/diff-guard
         with:
           target_db: ./vuls.db
           baseline_repository: ghcr.io/vulsio/vuls-nightly-db:nightly
           db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
-          db_change_rate_threshold_overrides: ${{ github.event.inputs.db_change_rate_threshold_overrides || '' }}
+          db_change_rate_threshold_overrides: ${{ github.event.inputs.db_change_rate_threshold_overrides || env.DB_CHANGE_RATE_THRESHOLD_OVERRIDES }}
           detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
-          detection_change_rate_threshold_overrides: ${{ github.event.inputs.detection_change_rate_threshold_overrides || '' }}
+          detection_change_rate_threshold_overrides: ${{ github.event.inputs.detection_change_rate_threshold_overrides || env.DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES }}
 
       # Guard passed: attach :nightly to the verified digest. If the guard
       # fails this step is skipped and

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -22,7 +22,18 @@ on:
           description) rather than at dispatch.
         required: false
         type: string
-        default: ""
+        # Persistent per-ecosystem overrides. Each entry is justified by
+        # recurring upstream-driven churn seen in db-nightly failures over
+        # the 2026-04-30..05-20 review window:
+        #   ubuntu:26.04=30 — Ubuntu 26.04 (future release): new-distro
+        #                     structural churn; observed ~17% db drift.
+        #   microsoft=35    — Microsoft KB bucket churns on the monthly
+        #                     Patch Tuesday cycle; observed KB rate 15-28%.
+        #   fedora:45=50    — Fedora 45 (recent release): observed ~39% drift.
+        default: |
+          ubuntu:26.04=30
+          microsoft=35
+          fedora:45=50
       detection_change_rate_threshold:
         description: "`vuls diff detection` default change rate (%) threshold per scan result; diff fails if exceeded"
         required: false
@@ -39,7 +50,19 @@ on:
           be added to this default in a PR.
         required: false
         type: string
-        default: ""
+        # Persistent per-file overrides. Each entry is justified by
+        # recurring upstream-driven churn seen in db-nightly failures over
+        # the 2026-04-30..05-20 review window:
+        #   debian_13=20           — Debian 13 (trixie): steady new-CVE
+        #                            inflow from the upstream feed; 5-14% drift.
+        #   ubuntu_2604=50         — Ubuntu 26.04 (future release):
+        #                            new-distro churn; observed 9-39% drift.
+        #   opensuse_tumbleweed=15 — rolling release, churns by design;
+        #                            observed ~7% drift.
+        default: |
+          debian_13=20
+          ubuntu_2604=50
+          opensuse_tumbleweed=15
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Seeds concrete per-target threshold overrides for the diff-guard nightly run, so the per-target threshold mechanism added in #146 actually relaxes the targets that have been tripping the guard for non-regression reasons.

```text
detection (default 5%)        db (default 10%)
  debian_13=20                  ubuntu:26.04=30
  ubuntu_2604=50                microsoft=35
  opensuse_tumbleweed=15        fedora:45=50
```

The lists live in the `build` job's `env` block (`DB_CHANGE_RATE_THRESHOLD_OVERRIDES` / `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES`) as the single source of truth. The `Run diff guard` step falls back to those env values when no `workflow_dispatch` `_overrides` input is supplied, so the overrides apply to **both** the scheduled cron run and manual dispatches. A non-empty `_overrides` dispatch input replaces the env list for that run only.

A general rationale for both override lists lives as a real YAML comment directly above the `env` entries — kept outside the `|` block scalar on purpose. That block scalar is plain data: vuls2's override parser reads every line as a `<key>=<rate>` entry and has no comment syntax (it never strips `#` lines), so a `#` line placed inside a list would be a malformed entry, not a comment. Per-entry rationale is not duplicated in the file — the per-target analysis is in the section below.

> **Why `env`, not the input `default:`** — `workflow_dispatch` input defaults are never materialized for `schedule` events (`github.event.inputs.*` is null on cron), so a seeded `default:` would never reach the scheduled run. The `env` block is visible to every event type. (Caught in review — fixed in 567acb6.)

## How the overrides were chosen

A review of **db-nightly failures over 2026-04-30 .. 05-20**: **47 failed runs across 7 events** (4 multi-run streaks + 3 isolated). 17 runs sampled (each streak's representatives + mid-streak spot checks); within a streak the same targets fail every run, so sampling is representative. Every failure in the window was a diff-guard trip (no build/push failures).

### FAIL targets observed

**detection diff** (default 5%)

| target | occurrences | rate range | nature |
| --- | --- | --- | --- |
| `debian_13` | multiple streaks (most frequent) | 5.1–14.1% | Debian 13 (trixie) — steady new-CVE inflow |
| `ubuntu_2604` | 3 events | 9.3–38.8% | Ubuntu 26.04 (future release) — new-distro churn |
| `amazon_2_extra_kernel` | 05-16~18 streak | 12.4% | Amazon 2 extra-kernel advisory churn |
| `oracle_8` | 05-13~14 streak | 6.7–7.0% | Oracle 8 (mature) — marginal |
| `opensuse_tumbleweed` | 05-06 | 7.1% | rolling release — churns by design |
| `opensuse_leap_16`, `…_kernel-default-base` | 05-10 | 100.0% | brand-new ecosystem (empty baseline) |
| `amazon_2023` / `debian_12` / `ubuntu_2404` | 1 each | 5.5–8.8% | current stable lines — single spikes |

**db diff** (default 10%)

| target | occurrences | rate | nature |
| --- | --- | --- | --- |
| `microsoft` | 05-13, 05-14, 05-18 | KB 15.6–28.2% | Microsoft KB bucket — monthly Patch Tuesday churn |
| `fedora:45` | 05-18 | 39.3% | Fedora 45 (recent release) |
| `ubuntu:26.04` | 05-20 | 17.0% | Ubuntu 26.04 (future release) |
| `ubuntu:16.04` | 05-20 | 39.5% | EOL distro — anomalous |

### Decision criteria

An override is warranted only when a target trips for **recurring, upstream-driven churn that is not a regression** — new distro generations, rolling releases, and monthly vendor-data cycles. A one-off spike on a mature distro is left to fail so a human looks at it.

- **Overridden (recurring churn / new distro):** `debian_13`, `ubuntu_2604`, `ubuntu:26.04`, `opensuse_tumbleweed`, `microsoft`, `fedora:45`. Values are set with headroom over the observed peak so routine churn passes while a genuine spike still trips.
- **Deliberately NOT overridden:**
  - `ubuntu:16.04` (39.5% db) — an **EOL** distro jumping 39% is not routine churn; left to fail so it is investigated rather than masked.
  - `oracle_8`, `amazon_2023`, `debian_12`, `ubuntu_2404`, `amazon_2_extra_kernel` — marginal, single-streak spikes on mature/current distros; overriding them would weaken the guard without a proven recurring need.
  - `opensuse_leap_16*` (100%) — a brand-new ecosystem with an empty baseline; self-resolves once `:nightly` promotes once, so no persistent override is warranted.

## Test plan

- [ ] Manual `workflow_dispatch` of db-nightly — confirm the seeded overrides appear in each diff report's `Threshold` column for the listed targets and that those targets PASS while everything else keeps the default threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

