### PR TITLE
feat(ci/db-main): seed per-target diff-guard threshold overrides

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -6,10 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       db_change_rate_threshold:
-        description: "`vuls diff db` default change rate (%) threshold per ecosystem; diff fails if exceeded"
+        description: |
+          `vuls diff db` default change rate (%) threshold per ecosystem;
+          diff fails if exceeded. Leave empty to use the build job's
+          DB_CHANGE_RATE_THRESHOLD env; a value here replaces it for this
+          dispatch only.
         required: false
         type: string
-        default: "10"
+        default: ""
       db_change_rate_threshold_overrides:
         description: |
           Per-ecosystem overrides of `vuls diff db` threshold, as
@@ -25,10 +29,14 @@ on:
         type: string
         default: ""
       detection_change_rate_threshold:
-        description: "`vuls diff detection` default change rate (%) threshold per scan result; diff fails if exceeded"
+        description: |
+          `vuls diff detection` default change rate (%) threshold per
+          scan result; diff fails if exceeded. Leave empty to use the
+          build job's DETECTION_CHANGE_RATE_THRESHOLD env; a value here
+          replaces it for this dispatch only.
         required: false
         type: string
-        default: "5"
+        default: ""
       detection_change_rate_threshold_overrides:
         description: |
           Per-scan-result-file overrides of `vuls diff detection`
@@ -56,13 +64,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOEXPERIMENT: jsonv2
-      # Persistent diff-guard threshold overrides — the single source of
+      # Persistent diff-guard threshold config — the single source of
       # truth, applied to BOTH scheduled and manually-dispatched runs.
       # workflow_dispatch input defaults are NOT visible to `schedule`
       # events, so the `Run diff guard` step falls back to these env
-      # values whenever no dispatch input is supplied. Each entry covers
-      # recurring upstream-driven churn (new-distro / recent-release
-      # cycles) found in a review of DB (db-main) workflow failures over
+      # values whenever no dispatch input is supplied; a dispatch input,
+      # when supplied, replaces the corresponding value for that run.
+      # Default per-target change-rate thresholds (%).
+      DB_CHANGE_RATE_THRESHOLD: "10"
+      DETECTION_CHANGE_RATE_THRESHOLD: "5"
+      # Per-target threshold overrides. Each entry covers recurring
+      # upstream-driven churn (new-distro / recent-release cycles) found
+      # in a review of DB (db-main) workflow failures over
       # 2026-05-01..05-20; run `git blame` on these lines for the commit
       # that introduced each entry and its rationale. `#` comments are
       # NOT allowed inside these lists (vuls2's override parser would
@@ -109,7 +122,7 @@ jobs:
 
       - name: Save vuls.db schema_version
         id: save_schema_version
-        run: echo "schema_version=$(vuls db search metadata --dbpath ./vuls.db | jq .schema_version)" >> $GITHUB_OUTPUT
+        run: echo "schema_version=$(vuls db search metadata --dbpath ./vuls.db | jq .schema_version)" >> "$GITHUB_OUTPUT"
 
       - name: Compact vuls.db
         run: vuls db compress --dbpath ./vuls.db
@@ -137,19 +150,17 @@ jobs:
       # Runs on every scheduled and manually dispatched invocation.
       - name: Run diff guard
         # On scheduled runs github.event.inputs.* is unset/null, so the
-        # `|| ...` fallbacks supply the values. Thresholds fall back to
-        # literals; the `_overrides` fall back to the job-level env lists
-        # (DB/DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES) so the persistent
-        # overrides apply to scheduled runs too. A workflow_dispatch
-        # `_overrides` input, when supplied, replaces the env list for
-        # that run.
+        # `|| env.*` fallbacks supply every value from the job-level env
+        # block (the single source of truth). A workflow_dispatch input,
+        # when supplied, replaces the corresponding env value for that
+        # run only.
         uses: ./.github/actions/diff-guard
         with:
           target_db: ./vuls.db
           baseline_repository: ghcr.io/vulsio/vuls-nightly-db:${{ steps.save_schema_version.outputs.schema_version }}
-          db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
+          db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || env.DB_CHANGE_RATE_THRESHOLD }}
           db_change_rate_threshold_overrides: ${{ github.event.inputs.db_change_rate_threshold_overrides || env.DB_CHANGE_RATE_THRESHOLD_OVERRIDES }}
-          detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
+          detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || env.DETECTION_CHANGE_RATE_THRESHOLD }}
           detection_change_rate_threshold_overrides: ${{ github.event.inputs.detection_change_rate_threshold_overrides || env.DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES }}
 
       # Guard passed: attach :latest and :<schema_version> to the verified digest.

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -6,13 +6,44 @@ on:
   workflow_dispatch:
     inputs:
       db_change_rate_threshold:
-        description: "`vuls diff db` change rate (%) threshold per ecosystem; diff fails if exceeded"
+        description: "`vuls diff db` default change rate (%) threshold per ecosystem; diff fails if exceeded"
         required: false
+        type: string
         default: "10"
-      detection_change_rate_threshold:
-        description: "`vuls diff detection` change rate (%) threshold per scan result; diff fails if exceeded"
+      db_change_rate_threshold_overrides:
+        description: |
+          Per-ecosystem overrides of `vuls diff db` threshold, as
+          multi-line "<ecosystem>=<rate>" entries. Leave empty to use the
+          persistent list in the build job's
+          DB_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty value here
+          replaces it for this dispatch only. A whitespace-only value
+          still counts as non-empty, so it replaces the env list with
+          nothing — use it to disable all persistent overrides for a
+          single dispatch. Blank/whitespace-only lines are dropped;
+          per-entry whitespace is trimmed by vuls2.
         required: false
+        type: string
+        default: ""
+      detection_change_rate_threshold:
+        description: "`vuls diff detection` default change rate (%) threshold per scan result; diff fails if exceeded"
+        required: false
+        type: string
         default: "5"
+      detection_change_rate_threshold_overrides:
+        description: |
+          Per-scan-result-file overrides of `vuls diff detection`
+          threshold, as multi-line "<file-basename>=<rate>" entries.
+          Leave empty to use the persistent list in the build job's
+          DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
+          value here replaces it for this dispatch only. A
+          whitespace-only value still counts as non-empty, so it
+          replaces the env list with nothing — use it to disable all
+          persistent overrides for a single dispatch.
+          Blank/whitespace-only lines are dropped; per-entry whitespace
+          is trimmed by vuls2.
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -25,6 +56,23 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOEXPERIMENT: jsonv2
+      # Persistent diff-guard threshold overrides — the single source of
+      # truth, applied to BOTH scheduled and manually-dispatched runs.
+      # workflow_dispatch input defaults are NOT visible to `schedule`
+      # events, so the `Run diff guard` step falls back to these env
+      # values whenever no dispatch input is supplied. Each entry covers
+      # recurring upstream-driven churn (new-distro / recent-release
+      # cycles) found in a review of DB (db-main) workflow failures over
+      # 2026-05-01..05-20; run `git blame` on these lines for the commit
+      # that introduced each entry and its rationale. `#` comments are
+      # NOT allowed inside these lists (vuls2's override parser would
+      # reject them).
+      DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
+        ubuntu:26.04=30
+        fedora:45=50
+      DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
+        debian_13=20
+        ubuntu_2604=50
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
@@ -88,15 +136,21 @@ jobs:
 
       # Runs on every scheduled and manually dispatched invocation.
       - name: Run diff guard
-        # On scheduled runs, github.event.inputs.* is typically unset/null
-        # rather than an empty string. The `|| 'default'` fallbacks below
-        # let this workflow run without workflow_dispatch inputs.
+        # On scheduled runs github.event.inputs.* is unset/null, so the
+        # `|| ...` fallbacks supply the values. Thresholds fall back to
+        # literals; the `_overrides` fall back to the job-level env lists
+        # (DB/DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES) so the persistent
+        # overrides apply to scheduled runs too. A workflow_dispatch
+        # `_overrides` input, when supplied, replaces the env list for
+        # that run.
         uses: ./.github/actions/diff-guard
         with:
           target_db: ./vuls.db
           baseline_repository: ghcr.io/vulsio/vuls-nightly-db:${{ steps.save_schema_version.outputs.schema_version }}
           db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
+          db_change_rate_threshold_overrides: ${{ github.event.inputs.db_change_rate_threshold_overrides || env.DB_CHANGE_RATE_THRESHOLD_OVERRIDES }}
           detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
+          detection_change_rate_threshold_overrides: ${{ github.event.inputs.detection_change_rate_threshold_overrides || env.DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES }}
 
       # Guard passed: attach :latest and :<schema_version> to the verified digest.
       # If the guard fails this step is skipped and the tags stay pointing at

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -6,10 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       db_change_rate_threshold:
-        description: "`vuls diff db` default change rate (%) threshold per ecosystem; diff fails if exceeded"
+        description: |
+          `vuls diff db` default change rate (%) threshold per ecosystem;
+          diff fails if exceeded. Leave empty to use the build job's
+          DB_CHANGE_RATE_THRESHOLD env; a value here replaces it for this
+          dispatch only.
         required: false
         type: string
-        default: "10"
+        default: ""
       db_change_rate_threshold_overrides:
         description: |
           Per-ecosystem overrides of `vuls diff db` threshold, as
@@ -25,10 +29,14 @@ on:
         type: string
         default: ""
       detection_change_rate_threshold:
-        description: "`vuls diff detection` default change rate (%) threshold per scan result; diff fails if exceeded"
+        description: |
+          `vuls diff detection` default change rate (%) threshold per
+          scan result; diff fails if exceeded. Leave empty to use the
+          build job's DETECTION_CHANGE_RATE_THRESHOLD env; a value here
+          replaces it for this dispatch only.
         required: false
         type: string
-        default: "5"
+        default: ""
       detection_change_rate_threshold_overrides:
         description: |
           Per-scan-result-file overrides of `vuls diff detection`
@@ -56,17 +64,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOEXPERIMENT: jsonv2
-      # Persistent diff-guard threshold overrides — the single source of
+      # Persistent diff-guard threshold config — the single source of
       # truth, applied to BOTH scheduled and manually-dispatched runs.
       # workflow_dispatch input defaults are NOT visible to `schedule`
       # events, so the `Run diff guard` step falls back to these env
-      # values whenever no dispatch input is supplied. Each entry covers
-      # recurring upstream-driven churn (new-distro / rolling-release /
-      # monthly vendor-data cycles) found in a review of db-nightly
-      # failures over 2026-04-30..05-20; run `git blame` on these lines
-      # for the commit that introduced each entry and its rationale.
-      # `#` comments are NOT allowed inside these lists (vuls2's override
-      # parser would reject them).
+      # values whenever no dispatch input is supplied; a dispatch input,
+      # when supplied, replaces the corresponding value for that run.
+      # Default per-target change-rate thresholds (%).
+      DB_CHANGE_RATE_THRESHOLD: "10"
+      DETECTION_CHANGE_RATE_THRESHOLD: "5"
+      # Per-target threshold overrides. Each entry covers recurring
+      # upstream-driven churn (new-distro / rolling-release / monthly
+      # vendor-data cycles) found in a review of db-nightly failures over
+      # 2026-04-30..05-20; run `git blame` on these lines for the commit
+      # that introduced each entry and its rationale. `#` comments are
+      # NOT allowed inside these lists (vuls2's override parser would
+      # reject them).
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
         microsoft=35
@@ -135,19 +148,17 @@ jobs:
       # Runs on every scheduled and manually dispatched invocation.
       - name: Run diff guard
         # On scheduled runs github.event.inputs.* is unset/null, so the
-        # `|| ...` fallbacks supply the values. Thresholds fall back to
-        # literals; the `_overrides` fall back to the job-level env lists
-        # (DB/DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES) so the persistent
-        # overrides apply to scheduled runs too. A workflow_dispatch
-        # `_overrides` input, when supplied, replaces the env list for
-        # that run.
+        # `|| env.*` fallbacks supply every value from the job-level env
+        # block (the single source of truth). A workflow_dispatch input,
+        # when supplied, replaces the corresponding env value for that
+        # run only.
         uses: ./.github/actions/diff-guard
         with:
           target_db: ./vuls.db
           baseline_repository: ghcr.io/vulsio/vuls-nightly-db:nightly
-          db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || '10' }}
+          db_change_rate_threshold: ${{ github.event.inputs.db_change_rate_threshold || env.DB_CHANGE_RATE_THRESHOLD }}
           db_change_rate_threshold_overrides: ${{ github.event.inputs.db_change_rate_threshold_overrides || env.DB_CHANGE_RATE_THRESHOLD_OVERRIDES }}
-          detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || '5' }}
+          detection_change_rate_threshold: ${{ github.event.inputs.detection_change_rate_threshold || env.DETECTION_CHANGE_RATE_THRESHOLD }}
           detection_change_rate_threshold_overrides: ${{ github.event.inputs.detection_change_rate_threshold_overrides || env.DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES }}
 
       # Guard passed: attach :nightly to the verified digest. If the guard


### PR DESCRIPTION
## Summary

Wires the per-target diff-guard threshold override mechanism — merged for `db-nightly` in #152 — into the **DB (`db-main`) workflow**, and seeds it with override values derived from `db-main`'s own failure history.

```text
detection (default 5%)   db (default 10%)
  debian_13=20             ubuntu:26.04=30
  ubuntu_2604=50           fedora:45=50
```

Mechanism (identical to #152):
- new `db_change_rate_threshold_overrides` / `detection_change_rate_threshold_overrides` `workflow_dispatch` inputs (`default: ""`);
- the persistent lists live in the `build` job's `env` (`DB_CHANGE_RATE_THRESHOLD_OVERRIDES` / `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES`) as the single source of truth — `workflow_dispatch` input defaults are never materialized for `schedule` events, so the `Run diff guard` step falls back to the `env` lists (`|| env.X`), applying the overrides to scheduled and manual runs alike;
- also adds the `type: string` declaration the existing two threshold inputs were missing, so the `workflow_dispatch` block matches `db-nightly.yml`.

## Threshold defaults: single source of truth

Copilot flagged that the default thresholds (`10` / `5`) were defined **twice** in each workflow — once in the `workflow_dispatch` input `default:` and again in the `Run diff guard` step's `|| '10'` / `|| '5'` fallback — so editing one without the other would silently diverge scheduled vs manually-dispatched runs. This PR closes that gap and completes the single-source-of-truth design:

- the thresholds move into the `build` job's `env` (`DB_CHANGE_RATE_THRESHOLD` / `DETECTION_CHANGE_RATE_THRESHOLD`), alongside the `_overrides` lists;
- the threshold inputs become `default: ""` and the step falls back to `|| env.X`, so every diff-guard value — thresholds and overrides alike — now has exactly **one** definition;
- applied to **both `db-main.yml` and `db-nightly.yml`** so the two workflows stay structurally identical (`db-nightly.yml` carried the same duplication after #152; fixing it here keeps the pair from drifting);
- also quotes `"$GITHUB_OUTPUT"` in db-main.yml's `save_schema_version` step (SC2086), matching every other step in the file.

## Why db-main needs this

The DB (`db-main`) workflow trips the diff guard about as often as `db-nightly` — **24 of the last 50 runs failed** — so the same operational pain (manual `:latest` promotion) applies. `db-main` is the user-facing stable DB, so keeping its guard meaningful matters most.

## How the overrides were chosen

Triage of **all 34 DB-workflow failures over 2026-05-01 .. 05-20**: **33 were diff-guard trips**, 1 was a CI-infrastructure flake (`25377929034` — the downstream summary job never acquired a runner; the DB itself passed and promoted). Every diff-guard trip got past Build DB and the tagless push.

### FAIL targets observed

**detection diff** (default 5%)

| target | runs | rate range | nature |
| --- | --- | --- | --- |
| `debian_13` | 14 | 5.1–7.9% | Debian 13 (trixie) — steady new-CVE inflow, ~6 distinct events across the whole window |
| `oracle_8` | 7 | 6.7–7.0% | Oracle 8 — one bulk vendor-advisory batch (single streak, 05-13~14) |
| `amazon_2_extra_kernel` | 6 | 12.4% (flat) | Amazon 2 extra-kernel — one batch stuck behind the guard (single streak, 05-16~17) |
| `amazon_2023` | 5 | 7.0% (flat) | Amazon 2023 — one batch stuck behind the guard (single streak, 05-09~10) |
| `ubuntu_2604` | 3 | 9.3–38.8% | Ubuntu 26.04 (future release) — tiny baseline, new-distro churn (3 distinct events) |
| `opensuse_leap_16` | 2 | 100.0% | brand-new ecosystem, empty baseline (0 → 1601) |
| `opensuse_leap_16_kernel-default-base` | 2 | 100.0% | brand-new ecosystem, empty baseline (0 → 1553) |
| `debian_12` | 2 | 5.1% | Debian 12 (stable) — marginal single streak |
| `ubuntu_2404` | 1 | 5.5% | Ubuntu 24.04 (stable) — single spike |

**db diff** (default 10%)

| target | runs | rate | nature |
| --- | --- | --- | --- |
| `ubuntu:26.04` | 3 | 17.0% (flat) | Ubuntu 26.04 (future release) — new-distro structural churn |
| `ubuntu:16.04` | 3 | 39.0–39.5% | EOL distro — anomalous |
| `fedora:45` | 1 | 39.3% | Fedora 45 (recent release) |

### Decision criteria

> An override is warranted only when a target trips for **recurring, upstream-driven churn that is not a regression** — new distro generations, recent releases, periodic vendor-data cycles. A one-off spike, or a single batch stuck behind the guard, is left to fail so a human looks at it.

A note on counting: a run fails if *any* target trips, and once a batch trips the guard, promotion is blocked — so the **same** batch re-fails every subsequent run until a human promotes. A flat, identical rate across a streak (`amazon_2_extra_kernel` 12.4%×6, `amazon_2023` 7.0%×5, `ubuntu:26.04` 17.0%×3) is the tell. Recurrence is judged by *distinct events*, not run count.

- **Overridden (recurring churn / new distro):**
  - `debian_13=20` — 14 runs across ~6 distinct events spanning the whole window; the chronic offender. The value is **intentionally wider** than db-main's own 7.9% peak would require (~12 would cover today's data): it matches db-nightly's `debian_13=20`, and Debian 13 (trixie) is a brand-new stable still backfilling CVEs — its rate keeps climbing (db-nightly has already observed up to 14.1%). 20 is forward-looking headroom for the next few months of trixie growth, chosen over having to re-loosen the override every few weeks. A genuine extraction regression on `debian_13` would swing far harder than 20% anyway, so the wider band does not meaningfully blunt the guard here.
  - `ubuntu_2604=50` — 3 distinct events; tiny detection baseline (≈150–260) makes small additions swing hard (38.8% → 14.5% → 9.3% as the baseline grows).
  - `ubuntu:26.04=30` — new-distro structural churn, steady 17.0%.
  - `fedora:45=50` — recent-release churn, 39.3%.
- **Deliberately NOT overridden:**
  - `oracle_8`, `amazon_2_extra_kernel`, `amazon_2023` — each is a **single upstream batch in one streak** on a mature distro (the flat identical rate confirms it is one batch stuck behind the guard, not N events). Per the criteria, left to fail; can be added in a follow-up if any recurs as a pattern across distinct events.
  - `opensuse_leap_16`, `opensuse_leap_16_kernel-default-base` — brand-new ecosystems with an empty baseline (100%); self-resolves after one promotion.
  - `debian_12`, `ubuntu_2404` — marginal single spikes on mature/current distros; overriding them would weaken the guard without a proven recurring need.
  - `ubuntu:16.04` — a 39% db-side change on an **EOL** distro is not routine churn; left to fail so it is investigated. (Triage also found its *detection*-report row is ~0% while its *db*-report rate is 39% — the metrics diverge sharply, another reason to surface it to a human.)

## Relationship to db-nightly (#152)

`db-main`'s seeded list is a **strict subset** of `db-nightly`'s, with **identical values** on every shared entry:

| | db-nightly (#152) | db-main (this PR) |
| --- | --- | --- |
| detection | `debian_13=20`, `ubuntu_2604=50`, `opensuse_tumbleweed=15` | `debian_13=20`, `ubuntu_2604=50` |
| db | `ubuntu:26.04=30`, `microsoft=35`, `fedora:45=50` | `ubuntu:26.04=30`, `fedora:45=50` |

`opensuse_tumbleweed` and `microsoft` did not trip `db-main` in this window, so they are not seeded here — the lists are deliberately data-driven per pipeline rather than copied. Values are kept identical to `db-nightly` so the two lists **converge** as ecosystems stabilize; the long-term goal is a single shared list (e.g. repo-level Variables) once the `win` / `cpe` migrations land.

## Test plan

- [ ] Manual `workflow_dispatch` of the DB workflow — confirm the seeded overrides appear in each diff report's `Threshold` column for `debian_13` / `ubuntu_2604` / `ubuntu:26.04` / `fedora:45`, that those targets PASS, and that everything else keeps the default threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


