### PR TITLE
feat(ci/diff-guard): add diff-guard override-grooming reminder workflow

### DIFF
--- a/.github/diff-guard-override-grooming-issue.md
+++ b/.github/diff-guard-override-grooming-issue.md
@@ -1,0 +1,27 @@
+## diff-guard override re-triage
+
+It is time for the periodic re-triage of the per-target diff-guard threshold overrides — the `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` / `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` env lists in `db-main.yml` and `db-nightly.yml`. This issue is filed automatically on a ~2-month cadence; **close it once the re-triage is done.**
+
+### Why this is needed
+
+The override lists were seeded (#152, #153) from a **failure-only** triage, which is structurally *additive*: it discovers overrides but never retires them — a target whose churn has subsided simply stops failing and disappears from a failure triage. Without a periodic groom the lists grow monotonically and the guard's signal degrades.
+
+### Policy
+
+**Input** — all `db-main` + `db-nightly` builds over the trailing ~2 months, **pass and fail alike**. PASS builds are the essential part: they are what reveal an override is no longer needed. The diff report prints a change-rate row for every target on every run, so each overridden target's full distribution over the window is directly observable.
+
+**Scope** — the whole override list is re-derived, not just appended to. For each existing entry, against the target's observed distribution over the window:
+
+- max observed ≤ the **default** threshold (db 10% / detection 5%) → **drop** the override;
+- would pass at a value below the current one → **narrow** it to (observed peak + headroom);
+- still needs the current value → **keep**.
+
+Then an additive pass for newly-recurring FAIL targets, using the same criteria as #152: an override is warranted only for recurring upstream-driven churn (new distros, recent releases, periodic vendor cycles) — not one-off spikes or a single batch stuck behind the guard.
+
+### Checklist
+
+- [ ] Pull the trailing ~2 months of `db-main` + `db-nightly` runs (pass and fail).
+- [ ] For each current override entry, tabulate the target's change-rate distribution → drop / narrow / keep.
+- [ ] Additive pass over newly-recurring FAIL targets.
+- [ ] Open a PR updating the override env lists in both workflows; link it here.
+- [ ] Close this issue.

--- a/.github/diff-guard-override-grooming-issue.md
+++ b/.github/diff-guard-override-grooming-issue.md
@@ -2,7 +2,7 @@
 
 It is time for the periodic re-triage of the per-target diff-guard threshold overrides — the `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` / `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` env lists in `db-main.yml` and `db-nightly.yml`. This issue is filed automatically on a ~2-month cadence; **close it once the re-triage is done.**
 
-> **How to process this issue:** follow the runbook at [`.github/diff-guard-override-grooming-runbook.md`](.github/diff-guard-override-grooming-runbook.md) — it has the exact commands, the log-parsing recipe, the decision rules, and the output conventions. The policy below is the summary.
+> **How to process this issue:** follow the runbook at [`.github/diff-guard-override-grooming-runbook.md`](https://github.com/vulsio/vuls-data-db/blob/main/.github/diff-guard-override-grooming-runbook.md) — it has the exact commands, the log-parsing recipe, the decision rules, and the output conventions. The policy below is the summary.
 
 ### Why this is needed
 

--- a/.github/diff-guard-override-grooming-issue.md
+++ b/.github/diff-guard-override-grooming-issue.md
@@ -2,6 +2,8 @@
 
 It is time for the periodic re-triage of the per-target diff-guard threshold overrides — the `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` / `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` env lists in `db-main.yml` and `db-nightly.yml`. This issue is filed automatically on a ~2-month cadence; **close it once the re-triage is done.**
 
+> **How to process this issue:** follow the runbook at [`.github/diff-guard-override-grooming-runbook.md`](.github/diff-guard-override-grooming-runbook.md) — it has the exact commands, the log-parsing recipe, the decision rules, and the output conventions. The policy below is the summary.
+
 ### Why this is needed
 
 The override lists were seeded (#152, #153) from a **failure-only** triage, which is structurally *additive*: it discovers overrides but never retires them — a target whose churn has subsided simply stops failing and disappears from a failure triage. Without a periodic groom the lists grow monotonically and the guard's signal degrades.

--- a/.github/diff-guard-override-grooming-runbook.md
+++ b/.github/diff-guard-override-grooming-runbook.md
@@ -1,0 +1,136 @@
+# diff-guard override grooming — runbook
+
+Executable procedure for the periodic re-triage of the diff-guard per-target
+threshold overrides. It is triggered by the auto-filed `diff-guard-grooming`
+issue (see `.github/workflows/diff-guard-override-grooming.yml`); hand this
+runbook to whoever works that issue — human or LLM. The issue body carries the
+*policy* (the summary); this file is the *procedure*.
+
+Repo: `vulsio/vuls-data-db`. The `gh` commands below omit `--repo
+vulsio/vuls-data-db` for brevity — add it, or run from a clone.
+
+## What you are grooming
+
+Two workflows run the diff guard, each on a 6-hour cron:
+
+- **`db-main.yml`** (workflow name `DB`) — builds from `BRANCH=main`, installs
+  `vuls@main`, baseline is the previous `:<schema_version>` image.
+- **`db-nightly.yml`** (workflow name `DB(Nightly)`) — builds from
+  `BRANCH=nightly`, installs `vuls@nightly`, baseline is the previous
+  `:nightly` image.
+
+Each workflow's `build` job carries two override lists in its `env:` block:
+
+- `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` — `<ecosystem>=<rate>` lines, for
+  `vuls diff db` (default threshold `DB_CHANGE_RATE_THRESHOLD`, 10%).
+- `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` — `<scan-result-file>=<rate>`
+  lines, for `vuls diff detection` (default `DETECTION_CHANGE_RATE_THRESHOLD`, 5%).
+
+Goal: re-derive both lists from the last ~2 months of data so they neither go
+stale (overrides for targets that have calmed down) nor miss newly-recurring
+churn. The whole list is re-derived, not just appended to.
+
+## Step 1 — Collect the run list
+
+Window: the trailing ~2 months from today. Metadata only (cheap):
+
+```
+gh run list --workflow db-main.yml    --created '>=<YYYY-MM-DD>' --limit 400 \
+  --json databaseId,conclusion,createdAt,event
+gh run list --workflow db-nightly.yml --created '>=<YYYY-MM-DD>' --limit 400 \
+  --json databaseId,conclusion,createdAt,event
+```
+
+You now have, per workflow, every run with its conclusion (~240 runs each).
+
+## Step 2 — Decide which run logs to read
+
+Do **not** fetch every run's log. You need:
+
+- **All FAIL runs** — group consecutive failures into *events*: a streak of
+  failures is usually one upstream cause re-failing because promotion is
+  blocked. Read 1–2 representative logs per FAIL event.
+- **A PASS sample** — to observe each *currently-overridden* target's rate when
+  it is not failing. This is the half a failure-only triage cannot see, and is
+  what lets you *retire* an override. Sample ~1 run every 3–4 days per workflow
+  from the PASS runs.
+
+Fetching logs is the expensive part — fan the reads out in parallel (runs are
+independent; e.g. several parallel workers/agents).
+
+## Step 3 — Extract the change-rate rows
+
+```
+gh run view <run-id> --log
+```
+
+The diff guard is a composite action; in these workflows its sub-steps may
+appear as `UNKNOWN STEP` in the log — **do not grep on the step name.** Grep on
+the report-table rows instead.
+
+The `Run diff guard` step prints a markdown report per diff. Column layouts vary
+slightly by `vuls` version, so read the header row to map columns. Typical:
+
+- **`vuls diff detection`** — `| Name | Baseline | Target | Added | Removed | Change Rate | [Threshold] | Result |`
+- **`vuls diff db`** — `| Ecosystem | Detection Change Rate | KB Change Rate | [Threshold] | Result |`
+
+For each sampled run, record per target: name, change rate(s), and Result
+(PASS / FAIL). The report lists *every* target, so one sampled run yields the
+full picture for that run.
+
+## Step 4 — Per-entry decision: drop / narrow / keep
+
+For **each entry currently in the override lists**, build the target's
+change-rate distribution over the window from the sampled runs, then:
+
+| observed over the window | action |
+|---|---|
+| max rate ≤ the **default** threshold (db 10% / detection 5%) | **drop** the override |
+| max rate ≤ a value lower than the current override | **narrow** to `(observed peak) + headroom` |
+| still needs the current value | **keep** |
+
+- **Headroom** — roughly 1.3–2× the observed peak. Exception: a *fast-growing
+  new distro* (a just-released stable still backfilling CVEs, etc.) warrants
+  forward-looking headroom beyond today's peak, since its rate will keep
+  climbing — re-loosening every cycle is worse than one wider band. Record the
+  reasoning in the PR.
+- **Stuck-batch caveat** — a target showing a *flat, identical rate across a
+  run streak* is one upstream batch re-failing behind a blocked promotion;
+  count it as **one event**, not N. Recurrence is judged by distinct events,
+  not run count.
+
+## Step 5 — Additive pass: new overrides
+
+From the FAIL events, find targets *not* currently overridden that tripped the
+guard. Add an override only for **recurring upstream-driven churn that is not a
+regression**:
+
+- ✅ new distro generations, recent releases, rolling releases, periodic
+  vendor-data cycles — recurring across **multiple distinct events**;
+- ❌ one-off spikes; a single stuck batch; EOL-distro anomalies; a brand-new
+  ecosystem with an empty baseline (100% — self-resolves after one promotion).
+
+Same criteria as #152 / #153 — see those PRs for worked FAIL tables and
+include/exclude rationale.
+
+## Step 6 — Apply
+
+Edit the `env:` blocks in **both** `.github/workflows/db-main.yml` and
+`.github/workflows/db-nightly.yml`:
+
+- `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` / `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES`.
+- One `<key>=<rate>` per line. **No `#` comments inside the lists** — vuls2's
+  override parser rejects them. Per-entry rationale goes in the PR description,
+  not the YAML.
+- The two pipelines have independent data (different data branch, different
+  `vuls` version, baseline-age effects), so their lists legitimately differ —
+  but where the **same** target is overridden in both, keep the **value
+  identical**: the lists are meant to converge.
+
+## Step 7 — Ship
+
+- Commit on a topic branch off the latest `main`; open a PR.
+- Put the FAIL/PASS evidence and the per-entry drop / narrow / keep / add
+  rationale in the PR description (mirror the format of #152 / #153).
+- Link the PR back to the `diff-guard-grooming` issue, then **close that
+  issue** — its checklist's last item.

--- a/.github/diff-guard-override-grooming-runbook.md
+++ b/.github/diff-guard-override-grooming-runbook.md
@@ -6,8 +6,8 @@ issue (see `.github/workflows/diff-guard-override-grooming.yml`); hand this
 runbook to whoever works that issue — human or LLM. The issue body carries the
 *policy* (the summary); this file is the *procedure*.
 
-Repo: `vulsio/vuls-data-db`. The `gh` commands below omit `--repo
-vulsio/vuls-data-db` for brevity — add it, or run from a clone.
+Repo: `vulsio/vuls-data-db`. The `gh` commands below omit
+`--repo vulsio/vuls-data-db` for brevity — add it, or run from a clone.
 
 ## What you are grooming
 

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -19,6 +19,12 @@ on:
     - cron: "7 9 1 * *" # 09:07 UTC on the 1st of every month
   workflow_dispatch:
 
+# Serialize runs so a manual dispatch overlapping the scheduled run
+# cannot both pass the "no open issue" gate and file a duplicate issue.
+concurrency:
+  group: diff-guard-override-grooming
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -11,8 +11,9 @@ name: diff-guard override grooming reminder
 # scheduled-workflow scheduler is best-effort and can drop a run, and
 # a low-frequency cron that misses a fire leaves a long gap nobody
 # notices. Firing monthly and self-gating to "only when the most
-# recent grooming issue is >= 2 months old" makes a missed fire
-# harmless — the following month picks it up.
+# recent grooming issue is at least 45 days old" yields an effective
+# ~2-month cadence and makes a missed fire harmless — the following
+# month picks it up.
 
 on:
   schedule:

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -1,0 +1,67 @@
+name: diff-guard override grooming reminder
+
+# Files a re-triage reminder issue for the diff-guard threshold
+# overrides (the DB_/DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env
+# lists in db-main.yml / db-nightly.yml) on a ~2-month cadence.
+#
+# The job fires MONTHLY rather than on a bimonthly cron: GitHub's
+# scheduled-workflow scheduler is best-effort and can drop a run, and
+# a low-frequency cron that misses a fire leaves a long gap nobody
+# notices. Firing monthly and self-gating to "only when the most
+# recent grooming issue is >= 2 months old" makes a missed fire
+# harmless — the following month picks it up.
+
+on:
+  schedule:
+    - cron: "7 9 1 * *" # 09:07 UTC on the 1st of every month
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remind:
+    name: file grooming issue when due
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out (for the issue body template)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: File grooming issue when due
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # A grooming issue is already open — the re-triage is still
+          # pending, so don't pile another one on top of it.
+          open_count=$(gh issue list --repo "$REPO" \
+            --label diff-guard-grooming --state open --json number --jq 'length')
+          if [ "$open_count" -gt 0 ]; then
+            echo "An open diff-guard-grooming issue already exists; nothing to do."
+            exit 0
+          fi
+
+          # The cron fires monthly, but the cadence is ~2 months: file a
+          # new issue only once the most recent grooming issue (open or
+          # closed) is at least 2 months old.
+          last=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
+            --state all --json createdAt \
+            --jq 'sort_by(.createdAt) | last | .createdAt // empty')
+          if [ -n "$last" ] && \
+             [ "$(date -u +%s)" -lt "$(date -u -d "$last + 2 months" +%s)" ]; then
+            echo "Most recent grooming issue ($last) is < 2 months old; not due yet."
+            exit 0
+          fi
+
+          # Ensure the label exists (idempotent — no manual setup step).
+          gh label create diff-guard-grooming --repo "$REPO" \
+            --color FBCA04 --description "Periodic diff-guard override re-triage" \
+            2>/dev/null || true
+
+          gh issue create --repo "$REPO" \
+            --label diff-guard-grooming \
+            --title "diff-guard override re-triage ($(date -u +%Y-%m))" \
+            --body-file .github/diff-guard-override-grooming-issue.md

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -54,15 +54,20 @@ jobs:
             exit 0
           fi
 
-          # The cron fires monthly, but the cadence is ~2 months: file a
-          # new issue only once the most recent grooming issue (open or
-          # closed) is at least 2 months old. `gh issue list` returns
-          # newest-first, so --limit 1 yields exactly that issue.
+          # The cron fires monthly; act on every other fire (~2-month
+          # cadence). Gate on a 45-day threshold, NOT an exact
+          # "+2 months": a "+2 months" cutoff falls on the very day the
+          # 2-months-later run fires, so cron jitter would decide ~50/50
+          # whether that run sees itself as due — a miss stretches the
+          # cadence to 3 months. 45 days sits safely between the monthly
+          # gaps (~30 days → skip, ~60 days → fire), so the outcome no
+          # longer depends on time-of-day. `gh issue list` returns
+          # newest-first, so --limit 1 yields exactly the latest issue.
           last=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
             --state all --limit 1 --json createdAt --jq '.[0].createdAt // empty')
           if [ -n "$last" ] && \
-             [ "$(date -u +%s)" -lt "$(date -u -d "$last + 2 months" +%s)" ]; then
-            echo "Most recent grooming issue ($last) is < 2 months old; not due yet."
+             [ "$(date -u +%s)" -lt "$(date -u -d "$last + 45 days" +%s)" ]; then
+            echo "Most recent grooming issue ($last) is < 45 days old; not due yet."
             exit 0
           fi
 

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -16,14 +16,15 @@ on:
     - cron: "7 9 1 * *" # 09:07 UTC on the 1st of every month
   workflow_dispatch:
 
-permissions:
-  contents: read
-  issues: write
+permissions: {}
 
 jobs:
   remind:
     name: file grooming issue when due
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out (for the issue body template)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -37,8 +38,8 @@ jobs:
 
           # A grooming issue is already open — the re-triage is still
           # pending, so don't pile another one on top of it.
-          open_count=$(gh issue list --repo "$REPO" \
-            --label diff-guard-grooming --state open --json number --jq 'length')
+          open_count=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
+            --state open --limit 1 --json number --jq 'length')
           if [ "$open_count" -gt 0 ]; then
             echo "An open diff-guard-grooming issue already exists; nothing to do."
             exit 0
@@ -48,7 +49,7 @@ jobs:
           # new issue only once the most recent grooming issue (open or
           # closed) is at least 2 months old.
           last=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
-            --state all --json createdAt \
+            --state all --limit 100 --json createdAt \
             --jq 'sort_by(.createdAt) | last | .createdAt // empty')
           if [ -n "$last" ] && \
              [ "$(date -u +%s)" -lt "$(date -u -d "$last + 2 months" +%s)" ]; then
@@ -56,10 +57,12 @@ jobs:
             exit 0
           fi
 
-          # Ensure the label exists (idempotent — no manual setup step).
-          gh label create diff-guard-grooming --repo "$REPO" \
-            --color FBCA04 --description "Periodic diff-guard override re-triage" \
-            2>/dev/null || true
+          # Ensure the label exists. --force makes this idempotent
+          # (create-or-update), so the expected "already exists" case is
+          # a no-op while real errors (rate limit, outage) still surface
+          # instead of being swallowed.
+          gh label create diff-guard-grooming --repo "$REPO" --force \
+            --color FBCA04 --description "Periodic diff-guard override re-triage"
 
           gh issue create --repo "$REPO" \
             --label diff-guard-grooming \

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -4,6 +4,9 @@ name: diff-guard override grooming reminder
 # overrides (the DB_/DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env
 # lists in db-main.yml / db-nightly.yml) on a ~2-month cadence.
 #
+# Prerequisite: the `diff-guard-grooming` label must already exist in
+# the repo — it is created once, out of band, not by this workflow.
+#
 # The job fires MONTHLY rather than on a bimonthly cron: GitHub's
 # scheduled-workflow scheduler is best-effort and can drop a run, and
 # a low-frequency cron that misses a fire leaves a long gap nobody
@@ -38,31 +41,24 @@ jobs:
 
           # A grooming issue is already open — the re-triage is still
           # pending, so don't pile another one on top of it.
-          open_count=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
-            --state open --limit 1 --json number --jq 'length')
-          if [ "$open_count" -gt 0 ]; then
-            echo "An open diff-guard-grooming issue already exists; nothing to do."
+          open_issue=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
+            --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$open_issue" ]; then
+            echo "diff-guard-grooming issue #$open_issue is already open; nothing to do."
             exit 0
           fi
 
           # The cron fires monthly, but the cadence is ~2 months: file a
           # new issue only once the most recent grooming issue (open or
-          # closed) is at least 2 months old.
+          # closed) is at least 2 months old. `gh issue list` returns
+          # newest-first, so --limit 1 yields exactly that issue.
           last=$(gh issue list --repo "$REPO" --label diff-guard-grooming \
-            --state all --limit 100 --json createdAt \
-            --jq 'sort_by(.createdAt) | last | .createdAt // empty')
+            --state all --limit 1 --json createdAt --jq '.[0].createdAt // empty')
           if [ -n "$last" ] && \
              [ "$(date -u +%s)" -lt "$(date -u -d "$last + 2 months" +%s)" ]; then
             echo "Most recent grooming issue ($last) is < 2 months old; not due yet."
             exit 0
           fi
-
-          # Ensure the label exists. --force makes this idempotent
-          # (create-or-update), so the expected "already exists" case is
-          # a no-op while real errors (rate limit, outage) still surface
-          # instead of being swallowed.
-          gh label create diff-guard-grooming --repo "$REPO" --force \
-            --color FBCA04 --description "Periodic diff-guard override re-triage"
 
           gh issue create --repo "$REPO" \
             --label diff-guard-grooming \

--- a/.github/workflows/diff-guard-override-grooming.yml
+++ b/.github/workflows/diff-guard-override-grooming.yml
@@ -66,5 +66,6 @@ jobs:
 
           gh issue create --repo "$REPO" \
             --label diff-guard-grooming \
+            --assignee MaineK00n --assignee shino \
             --title "diff-guard override re-triage ($(date -u +%Y-%m))" \
             --body-file .github/diff-guard-override-grooming-issue.md


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that periodically files a re-triage reminder issue for the diff-guard threshold overrides — the operational follow-up requested in the #153 review.

## Why

The per-target override lists in `db-main.yml` / `db-nightly.yml` were seeded (#152, #153) from a **failure-only** triage, which is structurally *additive*: it discovers overrides but never retires them — a target whose churn subsides just stops failing and drops out of view. Without a periodic groom the lists grow monotonically and the guard's signal degrades.

## What

- **`.github/workflows/diff-guard-override-grooming.yml`** — fires monthly (`cron` + `workflow_dispatch`) and self-gates to a **~2-month cadence**: it files a new `diff-guard-grooming`-labelled issue only when the most recent grooming issue is at least 45 days old, and skips while one is still open. The auto-filed issue is assigned to the maintainers.
- **`.github/diff-guard-override-grooming-issue.md`** — the issue body template: the grooming policy (the drop / narrow / keep rule) plus a re-triage checklist. Each cycle gets a fresh issue, worked and then closed.
- **`.github/diff-guard-override-grooming-runbook.md`** — the executable procedure for working a grooming issue: run collection, log-sampling, change-rate extraction, the decision rule, and the apply/ship conventions. The issue template links to it, so the auto-filed issue is a self-contained, executable task.

## Design notes

- **Why fire monthly, not bimonthly** — GitHub's scheduled-workflow scheduler is best-effort and can drop a run. A bimonthly cron that misses a fire leaves a ~4-month gap nobody notices. Firing monthly and putting the elapsed-time check in the job makes a missed fire harmless — the following month picks it up. The cadence lives in the job logic, not the cron expression.
- **45-day gate, not an exact "+2 months"** — the in-job check files a new issue once the last one is at least 45 days old. An exact `last + 2 months` cutoff would land on the very day the 2-months-later monthly run fires, so cron jitter would decide ~50/50 whether that run sees itself as due — and a miss would stretch the cadence to 3 months. 45 days sits safely between the monthly gaps (~30 days from the previous issue → skip, ~60 days → fire), so the outcome no longer depends on time-of-day.
- **No issue pile-up** — the job skips while a grooming issue is still open, so an un-actioned cycle does not spawn duplicates; the still-open issue is itself the standing reminder.
- **Label** — the `diff-guard-grooming` label is created once out of band (already done for this repo) and is documented as a prerequisite in the workflow header; the workflow consumes it and does not bootstrap it.
- This supersedes the standing policy issue #154 (now closed): a fresh issue per cycle, closed when done, is clearer than accumulating state on one long-lived issue.

## Test plan

The cron trigger is GitHub's scheduler — nothing to verify there. The job logic is exercised by `workflow_dispatch`, which runs the identical job, so a post-merge dispatch covers everything except the schedule trigger itself.

- [ ] After merge: `gh workflow run diff-guard-override-grooming.yml` — with no prior grooming issue the run files one; confirm its title, the `diff-guard-grooming` label, the assignees, and the body (including the runbook link).
- [ ] Dispatch a second time — a grooming issue is now open, so the run skips (`... is already open; nothing to do`), confirming the dedup gate.

Already verified standalone: the `gh issue list` queries handle the empty (no-prior-issue) state. The 45-day gate is plain `date` arithmetic (`now < last + 45 days`); the dispatch test above exercises the create path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
