### PR TITLE
chore(ci/diff-guard): add ubuntu:snap=30 db-rate override

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -82,6 +82,7 @@ jobs:
       # reject them).
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
+        ubuntu:snap=30
         fedora:45=50
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -74,12 +74,12 @@ jobs:
       DB_CHANGE_RATE_THRESHOLD: "10"
       DETECTION_CHANGE_RATE_THRESHOLD: "5"
       # Per-target threshold overrides. Each entry covers recurring
-      # upstream-driven churn (new-distro / recent-release cycles) found
-      # in a review of DB (db-main) workflow failures over
-      # 2026-05-01..05-20; run `git blame` on these lines for the commit
-      # that introduced each entry and its rationale. `#` comments are
-      # NOT allowed inside these lists (vuls2's override parser would
-      # reject them).
+      # upstream-driven churn (new-distro / recent-release / small-
+      # baseline cycles) surfaced by DB (db-main) diff-guard failures;
+      # entries are added incrementally as new sources of churn appear.
+      # Run `git blame` on these lines for the commit that introduced
+      # each entry and its rationale. `#` comments are NOT allowed
+      # inside these lists (vuls2's override parser would reject them).
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
         ubuntu:snap=30

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -82,6 +82,7 @@ jobs:
       # reject them).
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
+        ubuntu:snap=30
         microsoft=35
         fedora:45=50
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -75,11 +75,12 @@ jobs:
       DETECTION_CHANGE_RATE_THRESHOLD: "5"
       # Per-target threshold overrides. Each entry covers recurring
       # upstream-driven churn (new-distro / rolling-release / monthly
-      # vendor-data cycles) found in a review of db-nightly failures over
-      # 2026-04-30..05-20; run `git blame` on these lines for the commit
-      # that introduced each entry and its rationale. `#` comments are
-      # NOT allowed inside these lists (vuls2's override parser would
-      # reject them).
+      # vendor-data / small-baseline cycles) surfaced by db-nightly
+      # diff-guard failures; entries are added incrementally as new
+      # sources of churn appear. Run `git blame` on these lines for
+      # the commit that introduced each entry and its rationale. `#`
+      # comments are NOT allowed inside these lists (vuls2's override
+      # parser would reject them).
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
         ubuntu:snap=30


### PR DESCRIPTION
## Summary

- Add `ubuntu:snap=30` to `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` in both `db-main.yml` and `db-nightly.yml`.
- Unblocks scheduled DB / DB Nightly runs, which have been failing the diff guard on every scheduled invocation since 2026-05-23 08:00Z.

## Latest failed runs

- db-main (DB): https://github.com/vulsio/vuls-data-db/actions/runs/26369890091 (2026-05-24 18:54Z, scheduled)
- db-nightly (DB Nightly): https://github.com/vulsio/vuls-data-db/actions/runs/26370322919 (2026-05-24 19:14Z, scheduled)

Both show the identical FAIL row for `ubuntu:snap` and share the same upstream cause (see *Smoking gun* below).

## Smoking gun

Triage of [db-main run 26369890091](https://github.com/vulsio/vuls-data-db/actions/runs/26369890091) (representative; the [db-nightly run 26370322919](https://github.com/vulsio/vuls-data-db/actions/runs/26370322919) shows the identical FAIL row):

```
| Ecosystem   | Detection Change Rate | KB Change Rate | Threshold | Result |
| ubuntu:snap | 21.7%                 | 0.0%           | 10.0%     | FAIL   |
```

Anchors:

|             | digest                                                             | created_by                                              |
| ----------- | ------------------------------------------------------------------ | ------------------------------------------------------- |
| Baseline `:0` | `sha256:d99cb46514d604e6ebd10e19863677743830e72bfc189ff6985811d922e9868b` | `vuls v0.0.1-alpha.0.20260520015748-4012c541274e` |
| Target candidate | `sha256:8871c3e0c78c119fa01d6b9d1448174cd2afc10b4a20099bb0b41dc2ce7026c7` | same |

ubuntu-cve-tracker datasource anchors:

|          | raw                                            | extracted                                      |
| -------- | ---------------------------------------------- | ---------------------------------------------- |
| baseline | `14909141` (2026-05-22 14:28Z)                 | `c0b5bfdf` (2026-05-22 20:46Z)                 |
| target   | `282e9683` (2026-05-24 02:16Z)                 | `f1917eb3` (2026-05-24 05:24Z)                 |

- `created_by` identical → vuls2 builder ruled out.
- No commits in `pkg/{extract,fetch}/ubuntu/tracker/` of vuls-data-update in the window → extractor ruled out.
- All 13 added root IDs are **new files** in the raw repo (`active/2026/CVE-2026-39827.json` … `46598.json`), each carrying `"packages": { "snapd": { "releases": { "snap": { "status": "needs-triage" }, ... } } }`.
- Description references `go.dev/cl/781320` / `GO-2026-5016` → a Go crypto disclosure batch where Ubuntu's tracker flagged snapd's embedded `golang-go.crypto` copy.

Verdict: **upstream-driven**. ubuntu:snap baseline is small (57 → 70 root IDs), so a single upstream triage batch easily exceeds the 10% DB threshold. Same class of small-baseline churn that already justifies `ubuntu:26.04=30`.

## Why both workflows

Both `DB` (db-main) and `DB Nightly` failed with the identical row at the same time — they share the same ubuntu-cve-tracker raw data. db-main has had 7 consecutive scheduled failures (since 2026-05-23 08:00Z); db-nightly likewise.

## Choice of 30%

Matches the `ubuntu:26.04=30` headroom already in place for analogous small-baseline ecosystems. 21.7% observed, so 30% gives ~8 pts of headroom for the next upstream batch without making the guard a no-op.

## Test plan

- [ ] Trigger db-main via `workflow_dispatch` (or wait for the next scheduled run) and confirm `Run diff guard` passes.
- [ ] Same for db-nightly.
- [ ] Once a candidate is verified, promote it to `:0` (db-main) and `:nightly` (db-nightly) via `DB(Promote Digest)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
