### PR TITLE
ci(diff-guard): add microsoft db override and include windows fixtures

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -148,11 +148,12 @@ runs:
       shell: bash
       run: |
         mkdir -p ./scan-results
-        # Copy all scan results then drop the ones excluded from this vuls2
-        # detection diff: Windows (handled by gost) and CentOS — see
-        # vuls/detector/detector.go DetectPkgCves switch.
+        # Copy all scan results then drop CentOS, which vuls2 does not handle
+        # (see vuls/detector/detector.go DetectPkgCves switch). Windows is now
+        # KEPT: vuls0 master detects Windows via vuls2, so the windows fixtures
+        # exercise the microsoft data in the DB under test.
         cp ./integration/data/results/*.json ./scan-results/
-        rm -f ./scan-results/windows_*.json ./scan-results/centos_*.json
+        rm -f ./scan-results/centos_*.json
         ls -1 ./scan-results
 
         integration_sha=$(git -C ./integration rev-parse HEAD)
@@ -251,14 +252,21 @@ runs:
     - name: Prepare scan results for older-binary check (drop families unsupported by older vuls0)
       shell: bash
       run: |
-        # Start from the already-filtered master-HEAD set (windows/centos gone)
-        # and additionally remove families the pinned older vuls0 cannot
-        # process. This is expressed as a *blacklist* so new families added
-        # upstream are retained automatically; only known-broken ones need
-        # listing here. Update this set when bumping `vuls0_old_ref`.
+        # Start from the already-filtered master-HEAD set (centos gone) and
+        # additionally remove families the pinned older vuls0 cannot process.
+        # This is expressed as a *blacklist* so new families added upstream
+        # are retained automatically; only known-broken ones need listing
+        # here. Update this set when bumping `vuls0_old_ref`.
+        #
+        # Windows is removed here but KEPT for the master-HEAD check above:
+        # the pinned older vuls0 predates "detect windows with vuls2" and
+        # still routes Windows to gost, so it does not exercise the vuls2 DB.
+        # Drop windows from this older-binary set until `vuls0_old_ref` is
+        # bumped past that change.
         mkdir -p ./scan-results-old
         cp ./scan-results/*.json ./scan-results-old/
         rm -f \
+          ./scan-results-old/windows_*.json \
           ./scan-results-old/amazon_*.json \
           ./scan-results-old/debian_*.json \
           ./scan-results-old/leap.json \

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -83,6 +83,7 @@ jobs:
       DB_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         ubuntu:26.04=30
         ubuntu:snap=30
+        microsoft=35
         fedora:45=50
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20


### PR DESCRIPTION
## What
Two diff-guard adjustments that follow from #125 enabling `microsoft-*` in db-main:

1. **db-main.yml** — add `microsoft=35` to `DB_CHANGE_RATE_THRESHOLD_OVERRIDES`, mirroring `db-nightly.yml`.
2. **`.github/actions/diff-guard/action.yml`** — stop excluding `windows_*.json` from the **master-HEAD** detection set; keep excluding it from the **older-binary** set. CentOS stays excluded in both.

## Why
- db-main now builds a `microsoft` ecosystem and diffs it against the nightly baseline. Microsoft is churny (db-nightly already uses `microsoft=35`); without an override it is judged against the default **10%** db change-rate gate and trips it, blocking promotion.
- Windows fixtures now exercise the microsoft data in the DB under test, because vuls0 master detects Windows via vuls2 (future-architect/vuls *"detect windows with vuls2"*). The **pinned older vuls0** predates that change and still routes Windows to gost, so it does not exercise the vuls2 DB — windows stays excluded from `scan-results-old` until `vuls0_old_ref` is bumped past that change.

## ⚠️ Merge ordering (why this is a draft)
**Merge only AFTER** the vuls0 *"detect windows with vuls2"* change is in `future-architect/vuls` master. Until then the master-HEAD detection diff installs a vuls0 that still uses gost for Windows, so the windows fixtures would not exercise the vuls2 DB.

After the vuls0 change lands, re-run CI here: the first run is the first time the windows fixtures are diffed, so a per-file `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` entry for `windows_*` may need to be added based on the observed rate.

## Testing
- `yaml.safe_load` parses both files.
- diff-guard behavior is exercised by db-main / db-nightly CI (validated post-merge of the vuls0 change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
