### PR TITLE
chore(ci/diff-guard): add alma_10 / alma:10 = 100 overrides

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -87,6 +87,7 @@ jobs:
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20
         ubuntu_2604=50
+        alma_10=100
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -84,6 +84,7 @@ jobs:
         ubuntu:26.04=30
         ubuntu:snap=30
         fedora:45=50
+        alma:10=100
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20
         ubuntu_2604=50

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -86,6 +86,7 @@ jobs:
         ubuntu:snap=30
         microsoft=35
         fedora:45=50
+        alma:10=100
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20
         ubuntu_2604=50

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -90,6 +90,7 @@ jobs:
         debian_13=20
         ubuntu_2604=50
         opensuse_tumbleweed=15
+        alma_10=100
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5


### PR DESCRIPTION
## Summary

- AlmaLinux 10 retired/republished a large batch of ALSA advisories between `2026-05-21..2026-05-27`, shrinking the `alma_10` detection baseline from 259 to 60.
- Both diff-guard sides fail on the same churn, and both DB and DB(Nightly) workflows are affected:
  - Detection diff: `alma_10` 99.2% change rate vs 5% threshold.
  - DB diff: `alma:10` 99.7% detection-change-rate vs 10% threshold (KB-change-rate is 0% but does not gate the result).
- Add `alma_10=100` to `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` and `alma:10=100` to `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` so the next runs can promote.

## Upstream verification

Cross-checked against the live `https://errata.almalinux.org/10/errata.full.json`:

| | Count |
|---|---|
| `10/ALSA-2025` advisories deleted from raw in the baseline window | 33 |
| ...of those still present upstream | **0** |
| Unique CVE references those deleted advisories carried | 148 |
| ...of those still referenced upstream | 11 |
| ...completely gone upstream | **137** |

This is an intentional upstream re-curation, not a transient feed glitch. The raw and extracted dotgit movement faithfully reflects upstream; `pkg/extract/alma` in vuls-data-update has no commits in the window; the vuls2 builder `created_by` matches baseline exactly. Extractor and builder are ruled out.

## Failed runs

- DB: https://github.com/vulsio/vuls-data-db/actions/runs/26501231316
- DB(Nightly): https://github.com/vulsio/vuls-data-db/actions/runs/26503546716

## Why this is alma's first override

`alma_10` / `alma:10` has passed diff-guard until now, so this is the first override we're adding for the AlmaLinux family. The reason it suddenly tripped both sides simultaneously is that the baselines are small relative to other ecosystems — detection baseline 259 (target 60) and DB baseline 279 (target 196), against e.g. `ubuntu_2204` ~6.6k or `debian_9` ~14k. At that scale the default 5% / 10% rate-based thresholds are too tight: a single bulk upstream advisory event is enough to trip them. Today's churn just made that fragility surface for the first time. Setting `=100` accepts this scaling reality rather than treating each future upstream burst as a one-off; the entry can be tightened later once the post-republish baseline settles.

## Why 100?

Smallest integer that absorbs 99.2% / 99.7%.

## Test plan

- [ ] Next DB run passes diff-guard
- [ ] Next DB(Nightly) run passes diff-guard
- [ ] After 1-2 cycles, re-evaluate whether the override values can be tightened