### PR TITLE
chore(db): temporarily pin alma-errata extracted to last-passing commit

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -6,7 +6,11 @@ DBPATH := ~/.cache/vuls/vuls.db
 .PHONY: db-build
 db-build:
 	vuls db init --dbtype ${DBTYPE} --dbpath ${DBPATH}
-	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	# alma-errata: temporarily pinned to the last extracted commit that built a passing DB
+	# (extracted anchor of vuls-nightly-db@sha256:b97cdf2a — main :0/:latest at 2026-05-27).
+	# Upstream AlmaLinux 10 errata is mid-republish (large ALSA retirements); restore to
+	# ${BRANCH} once the new baseline settles.
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=564e8bdd1c936e2f09452a6370a0cd63c6b0be3d DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}

--- a/db-nightly.mk
+++ b/db-nightly.mk
@@ -6,7 +6,11 @@ DBPATH := ~/.cache/vuls/vuls.db
 .PHONY: db-build
 db-build:
 	vuls db init --dbtype ${DBTYPE} --dbpath ${DBPATH}
-	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	# alma-errata: temporarily pinned to the last extracted commit that built a passing DB
+	# (extracted anchor of vuls-nightly-db@sha256:06eb4252 — :nightly at 2026-05-27).
+	# Upstream AlmaLinux 10 errata is mid-republish (large ALSA retirements); restore to
+	# ${BRANCH} once the new baseline settles.
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=e6b3fdedd7b245088c5409500c015a3e316140c6 DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
## Summary

Workaround for the ongoing AlmaLinux 10 errata republish — keep other data sources promoting normally while alma-errata is in flux, by freezing the alma-errata extracted input to the last commit that produced a passing DB build.

Replaces the persistent-override approach proposed in #159 (which MaineK00n correctly objected to; this PR is the alternative). #159 can be closed once this lands.

## Approach

Each pipeline's `db-add` call for `vuls-data-extracted-alma-errata` is changed from `BRANCH=${BRANCH}` to a hard-coded commit hash. `vuls-data-update dotgit pull --checkout` accepts a commit hash (see `pkg/dotgit/pull/pull_test.go`), so the rest of the pipeline is unchanged. All other data sources still follow `${BRANCH}` and continue to update on every run.

| file | pinned commit | source |
|---|---|---|
| `db-main.mk` | `564e8bdd` | extracted anchor of `vuls-nightly-db@sha256:b97cdf2a` (`:0` / `:latest` at 2026-05-27) |
| `db-nightly.mk` | `e6b3fded` | extracted anchor of `vuls-nightly-db@sha256:06eb4252` (`:nightly` at 2026-05-27) |

Both pinned commits were captured at 2026-05-21, before the upstream republish began — alma_10 baseline at that point was 259 detections (the value diff-guard considers "normal").

## Why this and not a persistent override

Per the grooming runbook and #159 review:

- The republish is a one-off step-change, not recurring churn → it doesn't fit the persistent-override category.
- Setting `=100` would silently disable the diff-guard on a major RHEL clone for any future regression, not just this event.
- Pinning the input is scoped: the *only* thing held still is alma-errata; every other source keeps moving, so any future regression in alma-errata's *extractor* or *vuls2 builder* still surfaces as soon as we unpin.

## Restore path

When the new alma-errata baseline settles (upstream publishes a stable advisory set again, or the post-republish anchor becomes the operating baseline), revert these two lines back to `BRANCH=${BRANCH}`. The change is one Makefile line per file plus the comment block immediately above it.

## Failed runs (same root cause as #159)

- DB: https://github.com/vulsio/vuls-data-db/actions/runs/26501231316
- DB(Nightly): https://github.com/vulsio/vuls-data-db/actions/runs/26503546716

## Test plan

- [ ] Next DB run builds with the pinned alma-errata commit and passes diff-guard at default thresholds
- [ ] Next DB(Nightly) run does the same
- [ ] Other data sources still update normally on each run
- [ ] After upstream settles, unpin in a follow-up PR

## Local verification

Built the DB locally on this PR branch with every non-alma `db-add` line commented out (alma-only build), then read back the datasource metadata. The recorded `extracted.commit` / `extracted.date` match the pin in each Makefile exactly — and match the corresponding anchors of the last-passing `:0`/`:latest` and `:nightly` images.

**`db-main.mk` (pin → `564e8bdd`)**

```
$ vuls db search datasources --dbpath /tmp/alma-only-main.db
[
  {
    "id": "alma-errata",
    "name": "AlmaLinux Errata",
    "raw": [
      {
        "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-raw-alma-errata",
        "commit": "8255896abc588ec077d76d777120a42e10197c38",
        "date": "2026-05-21T16:06:28Z"
      }
    ],
    "extracted": {
      "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-extracted-alma-errata",
      "commit": "564e8bdd1c936e2f09452a6370a0cd63c6b0be3d",
      "date": "2026-05-21T21:48:36Z"
    }
  }
]
```

**`db-nightly.mk` (pin → `e6b3fded`)**

```
$ vuls db search datasources --dbpath /tmp/alma-only-nightly.db
[
  {
    "id": "alma-errata",
    "name": "AlmaLinux Errata",
    "raw": [
      {
        "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-raw-alma-errata",
        "commit": "8255896abc588ec077d76d777120a42e10197c38",
        "date": "2026-05-21T16:06:28Z"
      }
    ],
    "extracted": {
      "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-extracted-alma-errata",
      "commit": "e6b3fdedd7b245088c5409500c015a3e316140c6",
      "date": "2026-05-21T22:02:08Z"
    }
  }
]
```

Both extracted anchors match the alma-errata `extracted.commit` recorded in the last successful DB images (`vuls-nightly-db@sha256:b97cdf2a` for `:0`/`:latest` and `@sha256:06eb4252` for `:nightly`), confirming the Makefile pin reproduces the intended state.
