### PR TITLE
feat(ci/db): show promote-digest gh command in candidate image summary

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -136,6 +136,8 @@ jobs:
       # only when the guard step below passes.
       - name: Push vuls.db to GHCR (tagless, digest-only)
         id: push
+        env:
+          SCHEMA_VERSION: ${{ steps.save_schema_version.outputs.schema_version }}
         run: |
           set -euo pipefail
           digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" ghcr.io/vulsio/vuls-nightly-db ./vuls.db.zst)
@@ -147,6 +149,16 @@ jobs:
             echo '```'
             echo "Image is always pushed before the diff guard runs; a failing"
             echo "build stays pullable by digest for investigation."
+            echo ""
+            echo "If the diff guard fails and an operator decides the candidate is"
+            echo "safe after inspecting the diff, promote it via the promote-digest"
+            echo "workflow (records an audit trail as an Actions run):"
+            echo '```sh'
+            echo " gh workflow run promote-digest.yml -R ${{ github.repository }} -f digest=${digest} -f tag=${SCHEMA_VERSION}"
+            echo '```'
+            echo '```sh'
+            echo " gh workflow run promote-digest.yml -R ${{ github.repository }} -f digest=${digest} -f tag=latest"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       # Runs on every scheduled and manually dispatched invocation.

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -145,6 +145,13 @@ jobs:
             echo '```'
             echo "Image is always pushed before the diff guard runs; a failing"
             echo "build stays pullable by digest for investigation."
+            echo ""
+            echo "If the diff guard fails and an operator decides the candidate is"
+            echo "safe after inspecting the diff, promote it via the promote-digest"
+            echo "workflow (records an audit trail as an Actions run):"
+            echo '```sh'
+            echo " gh workflow run promote-digest.yml -R ${{ github.repository }} -f digest=${digest} -f tag=nightly"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       # Runs on every scheduled and manually dispatched invocation.

--- a/.github/workflows/promote-digest.yml
+++ b/.github/workflows/promote-digest.yml
@@ -1,6 +1,6 @@
 name: DB(Promote Digest)
 
-run-name: "Promote ${{ inputs.digest }} -> :${{ inputs.tag }} by @${{ github.actor }}"
+run-name: "Promote :${{ inputs.tag }} <- ${{ inputs.digest }} by @${{ github.actor }}"
 
 # Manual recovery workflow for attaching a tag (latest / nightly / 0) to a
 # tagless image digest on ghcr.io/vulsio/vuls-nightly-db.


### PR DESCRIPTION
## What

- Add a ready-to-paste `gh workflow run promote-digest.yml` command to the **Pushed candidate image (untagged, digest-only)** step summary in `db-main.yml` and `db-nightly.yml`.
- Reorder the `promote-digest.yml` `run-name` so the tag is shown before the digest.

## Why

`db-main` / `db-nightly` always push the candidate image tagless first, then promote a tag onto the verified digest only when the diff guard passes. When the guard fails, the candidate stays untagged. If an operator inspects the diff and decides it is safe, they currently have to hand-assemble the `promote-digest` dispatch with the right digest and tag. Printing the exact command in the run summary makes that recovery path copy-paste.

Separately, in the promote-digest run list the 64-char sha256 digest pushed the tag off the visible end of each row, hiding the most important part (which tag is being promoted).

## Details

- **db-main**: one command per tag (`<schema_version>` and `latest`), in separate code blocks so each can be copied independently.
- **db-nightly**: one command for the `nightly` tag.
- Each command line has a leading space to keep it out of shell history (`HISTCONTROL=ignorespace`).
- `schema_version` is bound to a `SCHEMA_VERSION` env var instead of being interpolated into the run script, matching the existing Promote step (avoids `${{ }}` in `run:`).
- **promote-digest run-name**: changed from `Promote <digest> -> :<tag>` to `Promote :<tag> <- <digest>` so the tag stays visible in the workflow run list.

## Note

`promote-digest.yml`'s `tag` input is a `choice` fixed to `latest` / `nightly` / `0`. The db-main `<schema_version>` command assumes the schema version stays `0`; if it ever changes, the choice list there would need updating too (pre-existing constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)