### PR TITLE
ci(diff-guard): bump vuls0_old_ref and drop only windows for older binary

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -94,7 +94,7 @@ inputs:
   vuls0_old_ref:
     description: future-architect/vuls commit SHA for the older-binary detection check.
     required: false
-    default: 4cc910824a2880fbfb322dd4e9d94b68558bed57
+    default: 3266337a725b1209503128a32187e09b39c89b5d
 
 runs:
   using: composite
@@ -266,13 +266,7 @@ runs:
         mkdir -p ./scan-results-old
         cp ./scan-results/*.json ./scan-results-old/
         rm -f \
-          ./scan-results-old/windows_*.json \
-          ./scan-results-old/amazon_*.json \
-          ./scan-results-old/debian_*.json \
-          ./scan-results-old/leap.json \
-          ./scan-results-old/opensuse_*.json \
-          ./scan-results-old/sles*.json \
-          ./scan-results-old/suse_*.json
+          ./scan-results-old/windows_*.json
         ls -1 ./scan-results-old
 
     - name: Diff detection with older vuls0 binary (baseline vs target DB)


### PR DESCRIPTION
## Summary
- Bump the older-binary detection check's pinned `vuls0_old_ref` to [`3266337`](https://github.com/future-architect/vuls/commit/3266337a725b1209503128a32187e09b39c89b5d).
- The newer pinned binary can now process `amazon`, `debian`, `leap`, `opensuse`, `sles` and `suse` families, so they are no longer stripped from the older-binary scan-results set.
- Windows is still routed to gost by this pinned binary (predates "detect windows with vuls2"), so it remains the **only** family dropped from the older-binary diff detection scan results.

## Changes
- `.github/actions/diff-guard/action.yml`
  - `vuls0_old_ref` default: `4cc9108…` → `3266337…`
  - older-binary scan-results `rm -f` blacklist reduced to just `windows_*.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)