### PR TITLE
ci(diff-guard): add windows_* detection change-rate overrides (10/20%)

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -88,6 +88,33 @@ jobs:
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20
         ubuntu_2604=50
+        windows_7=10
+        windows_81=10
+        windows_10_1709=10
+        windows_10_1803=10
+        windows_10_1809=10
+        windows_10_1903=10
+        windows_10_1909=10
+        windows_10_2004=10
+        windows_10_20h2=10
+        windows_10_21h1=10
+        windows_10_21h2=10
+        windows_10_21h2_old=10
+        windows_10_22h2=10
+        windows_11_21h2=10
+        windows_11_22h2=10
+        windows_11_23h2=20
+        windows_11_24h2=20
+        windows_11_25h2=20
+        windows_server_2008=10
+        windows_server_2008_r2=10
+        windows_server_2012=10
+        windows_server_2012_r2=10
+        windows_server_2016=10
+        windows_server_2019=10
+        windows_server_2022=20
+        windows_server_2022_sql_server_2019=20
+        windows_server_2025=20
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -90,6 +90,33 @@ jobs:
         debian_13=20
         ubuntu_2604=50
         opensuse_tumbleweed=15
+        windows_7=10
+        windows_81=10
+        windows_10_1709=10
+        windows_10_1803=10
+        windows_10_1809=10
+        windows_10_1903=10
+        windows_10_1909=10
+        windows_10_2004=10
+        windows_10_20h2=10
+        windows_10_21h1=10
+        windows_10_21h2=10
+        windows_10_21h2_old=10
+        windows_10_22h2=10
+        windows_11_21h2=10
+        windows_11_22h2=10
+        windows_11_23h2=20
+        windows_11_24h2=20
+        windows_11_25h2=20
+        windows_server_2008=10
+        windows_server_2008_r2=10
+        windows_server_2012=10
+        windows_server_2012_r2=10
+        windows_server_2016=10
+        windows_server_2019=10
+        windows_server_2022=20
+        windows_server_2022_sql_server_2019=20
+        windows_server_2025=20
     steps:
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5


### PR DESCRIPTION
## What

Add per-file `vuls diff detection` change-rate overrides for all 27 `windows_*` scan results, in both `db-main.yml` and `db-nightly.yml`, split into two tiers: **20%** for high-churn recent versions, **10%** for everything else.

## Why

The detection master-HEAD check trips its default **5%** gate on the Windows scan results roughly once a month. Each Microsoft **Patch Tuesday** publishes a batch of new advisories/KBs, so every `windows_*.json` detection result jumps **additively** (Added-only, Removed 0).

Smoking gun — [run 27304209180](https://github.com/vulsio/vuls-data-db/actions/runs/27304209180) (db-nightly, 2026-06-10, the day after the 2026-06-09 Patch Tuesday): **13 windows files failed at 5.3%–14.2%**.

| scan result | Baseline | Target | Added | Rate | Tier |
|---|--:|--:|--:|--:|--:|
| windows_11_25h2 | 1081 | 1235 | 154 | **14.2%** | 20% |
| windows_11_24h2 | 1088 | 1242 | 154 | **14.2%** | 20% |
| windows_server_2022 | 1083 | 1235 | 152 | 14.0% | 20% |
| windows_11_23h2 | 1082 | 1230 | 148 | 13.7% | 20% |
| windows_server_2025 | 1644 | 1802 | 158 | 9.6% | 20% |
| windows_server_2022_sql_server_2019 | 1608 | 1760 | 152 | 9.5% | 20% |
| windows_server_2019 | 1270 | 1360 | 90 | 7.1% | 10% |
| windows_11_21h2 / 22h2 | | | ~47 | 5.6% | 10% |
| windows_server_2012 / 2012_r2 / 2016 | | | 62–76 | 5.3–5.5% | 10% |
| windows_10_22h2 | 2558 | 2697 | 139 | 5.4% | 10% |

This is the **detection-side analogue of the existing DB-side `microsoft=35`** override. #158 added the windows fixtures to the detection set but left the detection threshold at the global 5%, so the Microsoft churn that the DB diff already tolerates at 35% kept tripping the detection gate.

## Details

- vuls2's override matching is **exact (no glob)**, and which windows files breach 5% **rotates month to month** as baselines grow, so all 27 `windows_*` scan results are enumerated rather than only the currently-failing subset.
- **Two tiers**, keyed to this Patch Tuesday's spike so each file's gate stays as tight as its churn allows:
  - **20%** — high-churn recent versions (>7.1%): `windows_11_23h2/24h2/25h2`, `windows_server_2022/2025`, `windows_server_2022_sql_server_2019`.
  - **10%** — everything else, including `windows_server_2019` (7.1%) and the older small-diff versions that stayed under 5%.
- Both tiers stay well under the 35% used for the microsoft DB ecosystem — a true 2x corruption would still fail.
- Applied to **both** db-main and db-nightly since they share the same detection set (windows fixtures included via #158).

## Note

Earlier failure clusters that looked Windows-related were actually `rocky_10` (5/30–31: 34.4%, 6/6–7: 8.7%); Windows detection was 0% in those. 6/10 is the first Windows detection failure on record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)