### PR TITLE
ci(diff-guard): raise rocky_10 detection threshold to 20%

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -88,6 +88,7 @@ jobs:
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20
         ubuntu_2604=50
+        rocky_10=20
         windows_7=10
         windows_81=10
         windows_10_1709=10

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -89,6 +89,7 @@ jobs:
       DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES: |
         debian_13=20
         ubuntu_2604=50
+        rocky_10=20
         opensuse_tumbleweed=15
         windows_7=10
         windows_81=10


### PR DESCRIPTION
## What

Add a per-target diff-guard override `rocky_10=20` to `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` in **both** DB workflows — `.github/workflows/db-main.yml` (**DB**) and `.github/workflows/db-nightly.yml` (**DB Nightly**) — raising the `vuls diff detection` change-rate threshold for `rocky_10` from the global 5% to 20% and keeping the two workflows in sync.

## Why

`rocky_10` is a young, small-baseline detection target. Routine upstream Rocky Linux 10 errata batches produce a large *relative* change rate against the small baseline and repeatedly trip the global 5% threshold, failing the DB workflow even though the candidate DB is sound:

| Run | Date | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
|---|---|---|---|---|---|---|---|---|
| [27508894556](https://github.com/vulsio/vuls-data-db/actions/runs/27508894556) | 2026-06-14 | 205 | 227 | +22 | 0 | **10.7%** | 5.0% | FAIL |
| [26731457315](https://github.com/vulsio/vuls-data-db/actions/runs/26731457315) | 2026-06-01 | 122 | 164 | +42 | 0 | **34.4%** | 5.0% | FAIL |

Both failures were triaged as **upstream-driven**:
- **raw** `rocky-errata` moved — new `RLSA-2026:*` advisories with `affected_products[].major_version == 10` (e.g. the 06-14 run added 8 such advisories: RLSA-2026:24985, 25111, 25112, 25115, 25191, 25216, 25225, 25237).
- **extractor** unchanged (no commits under `pkg/extract/rocky` or `pkg/fetch/rocky` in the affected window).
- **vuls2 builder** unchanged (identical `created_by` in baseline vs candidate DB metadata).

i.e. legitimate new Rocky 10 errata, faithfully extracted — not a pipeline regression.

## Choice of 20%

As the `rocky_10` baseline grows (122 → 205 over two weeks), equivalent upstream batches shrink in relative terms, so a 20% per-target override covers the current regime while still catching genuinely anomalous churn. This mirrors the existing `debian_13=20` entry for the same class of recent-release / small-baseline churn.

Note: the 2026-06-01 spike (34.4%, baseline 122) predates this threshold and would not have been covered by 20% — it reflects the initial post-launch seeding of Rocky 10 coverage rather than the steady-state regime this override targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)