### PR TITLE
feat(ci): add vulncheck-nist-nvd2 to extract and nightly db

### DIFF
--- a/.github/workflows/backup-daily.yml
+++ b/.github/workflows/backup-daily.yml
@@ -59,6 +59,7 @@ jobs:
           - vuls-data-extracted-suse-oval
           - vuls-data-extracted-ubuntu-cve-tracker
           - vuls-data-extracted-vulncheck-kev
+          - vuls-data-extracted-vulncheck-nist-nvd2
           - vuls-data-raw-alma-errata
           - vuls-data-raw-alma-osv
           - vuls-data-raw-alma-oval

--- a/.github/workflows/backup-monthly.yml
+++ b/.github/workflows/backup-monthly.yml
@@ -59,6 +59,7 @@ jobs:
           - vuls-data-extracted-suse-oval
           - vuls-data-extracted-ubuntu-cve-tracker
           - vuls-data-extracted-vulncheck-kev
+          - vuls-data-extracted-vulncheck-nist-nvd2
           - vuls-data-raw-alma-errata
           - vuls-data-raw-alma-osv
           - vuls-data-raw-alma-oval

--- a/.github/workflows/backup-weekly.yml
+++ b/.github/workflows/backup-weekly.yml
@@ -59,6 +59,7 @@ jobs:
           - vuls-data-extracted-suse-oval
           - vuls-data-extracted-ubuntu-cve-tracker
           - vuls-data-extracted-vulncheck-kev
+          - vuls-data-extracted-vulncheck-nist-nvd2
           - vuls-data-raw-alma-errata
           - vuls-data-raw-alma-osv
           - vuls-data-raw-alma-oval

--- a/.github/workflows/extract-all.yml
+++ b/.github/workflows/extract-all.yml
@@ -138,6 +138,7 @@ jobs:
           # - "ubuntu-osv"
           # - "ubuntu-vex"
           - "vulncheck-kev"
+          - "vulncheck-nist-nvd2"
           # - "wolfi-osv"
     uses: ./.github/workflows/extract-main.yml
     permissions:
@@ -270,6 +271,7 @@ jobs:
           # - "ubuntu-osv"
           # - "ubuntu-vex"
           - "vulncheck-kev"
+          - "vulncheck-nist-nvd2"
           # - "wolfi-osv"
     uses: ./.github/workflows/extract-main.yml
     permissions:

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -131,6 +131,7 @@ on:
           # - ubuntu-osv
           # - ubuntu-vex
           - vulncheck-kev
+          - vulncheck-nist-nvd2
           # - wolfi-osv
       branch:
         required: true

--- a/.github/workflows/gc-extracted.yml
+++ b/.github/workflows/gc-extracted.yml
@@ -148,6 +148,9 @@ jobs:
           - tag: vuls-data-extracted-vulncheck-kev
             pack-threads: 2
             pack-windowMemory: 4g
+          - tag: vuls-data-extracted-vulncheck-nist-nvd2
+            pack-threads: 2
+            pack-windowMemory: 4g
     uses: ./.github/workflows/gc.yml
     permissions:
       contents: read

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -70,6 +70,7 @@ on:
           - vuls-data-extracted-suse-oval
           - vuls-data-extracted-ubuntu-cve-tracker
           - vuls-data-extracted-vulncheck-kev
+          - vuls-data-extracted-vulncheck-nist-nvd2
           - vuls-data-raw-alma-errata
           - vuls-data-raw-alma-osv
           - vuls-data-raw-alma-oval

--- a/.github/workflows/restore-all.yml
+++ b/.github/workflows/restore-all.yml
@@ -67,6 +67,7 @@ jobs:
           - vuls-data-extracted-suse-oval
           - vuls-data-extracted-ubuntu-cve-tracker
           - vuls-data-extracted-vulncheck-kev
+          - vuls-data-extracted-vulncheck-nist-nvd2
           - vuls-data-raw-alma-errata
           - vuls-data-raw-alma-osv
           - vuls-data-raw-alma-oval

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -58,6 +58,7 @@ on:
           - vuls-data-extracted-suse-oval
           - vuls-data-extracted-ubuntu-cve-tracker
           - vuls-data-extracted-vulncheck-kev
+          - vuls-data-extracted-vulncheck-nist-nvd2
       threshold-mb:
         required: true
         type: number

--- a/db-main.mk
+++ b/db-main.mk
@@ -38,6 +38,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-suse-oval BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-ubuntu-cve-tracker BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-nist-nvd2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 
 .PHONY: db-add
 db-add:

--- a/db-nightly.mk
+++ b/db-nightly.mk
@@ -38,6 +38,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-suse-oval BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-ubuntu-cve-tracker BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-nist-nvd2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 
 .PHONY: db-add
 db-add:


### PR DESCRIPTION
## What

Wire the new `vulncheck-nist-nvd2` extractor (added in MaineK00n/vuls-data-update#842) into the data pipeline, mirroring the `nvd-feed-cve-v2` footprint.

## How

- **extract**: add to `extract-all.yml` (both `extract-main` (main) and `extract-main-nightly` (nightly) matrices) and the `extract-main.yml` dispatch list. It is a single-input extractor (reads only its own raw dotgit), so it uses the generic `extract-main.yml` like `vulncheck-kev` — not a dedicated workflow.
- **nightly db** (`db-nightly.mk`): `db-add` active → included in the nightly DB.
- **main db** (`db-main.mk`): `db-add` commented out → excluded from the main DB for now, matching how `nvd-feed-cve-v2` is staged.
- **lifecycle**: register `vuls-data-extracted-vulncheck-nist-nvd2` in `backup-daily` / `-weekly` / `-monthly`, `gc`, `gc-extracted`, `restore-all`, and `truncate`.

## Testing

- `actionlint` on the edited workflows: no new findings (only pre-existing shellcheck-info in untouched `run:` blocks).
- `make -n` on `db-nightly.mk` and `db-main.mk`: syntax OK (tabs correct). The `db-main.mk` entry is a shell no-op (commented), confirmed it does not add `vulncheck-nist-nvd2` to the main DB — identical behavior to the existing `nvd-feed-cve-v2` commented entry.

Actual nightly-DB inclusion takes effect after merge, on the next scheduled `db-nightly` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)