### PR TITLE
ci(db): enable nvd-feed-cve-v2 in db-main

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -30,7 +30,7 @@ db-build:
 	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-mitre-cve-v5 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-msf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-nuclei-repository BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-nvd-feed-cve-v2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-nvd-feed-cve-v2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-oracle-linux BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-redhat-cve BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-redhat-vex-v1-rhel BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
This pull request makes a small but important change to the `db-main.mk` build script. The line for adding the `vuls-data-extracted-nvd-feed-cve-v2` database repository is uncommented, so this database will now be included during the build process.

* [`db-main.mk`](diffhunk://#diff-0c6c0a431045b1891703108843bd4ac79d6606d6539fc5123b370345a60022baL33-R33): Enabled the addition of the `vuls-data-extracted-nvd-feed-cve-v2` repository in the `db-build` target by uncommenting the relevant line.