### PR TITLE
ci(db): enable mitre-cve-v5 in db-main

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -29,7 +29,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-microsoft-wsusscn2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-mitre-attack BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-mitre-capec BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-mitre-cve-v5 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-mitre-cve-v5 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-mitre-cwe BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-msf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-nuclei-repository BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
Uncomment `vuls-data-extracted-mitre-cve-v5` in `db-main.mk` so MITRE CVE v5 is included in the main DB build.

This backs the vuls-side MITRE CVE v5 enrich support in future-architect/vuls#2586, which reads `mitre-cve-v5` data from the vuls2 DB.

Only `db-main.mk` is enabled here (matching #174 for `nvd-feed-cve-v2`); `db-nightly.mk` is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)