### PR TITLE
ci(db): enable cisco-json in the main (:latest/:0) DB build

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -14,7 +14,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisco-json BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisco-json BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-debian-security-tracker-salsa BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-enisa-euvd-list BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-enisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
> [!CAUTION]
> ## ⚠️ DO NOT MERGE until the vuls0 Cisco PR is merged first ⚠️
> This enables **cisco-json** in the production main DB (`:0` / `:latest`). vuls0 must already route Cisco detection through vuls2 before this lands, otherwise `:latest` consumers get Cisco advisory data that the released vuls0 detects via **both** go-cve-dictionary **and** vuls2 (double-reporting / strip mismatch).
>
> **Merge order: future-architect/vuls#2581 (route Cisco to vuls2) → THEN this PR.**

## What

`cisco-json` was already listed in `db-main.mk` but **commented out**. This uncomments it so the main DB build (`:0` / `:latest`) includes Cisco Security Advisories.

`db-nightly.mk` already builds with `cisco-json` enabled (nightly is the preview tag); this brings `main` in line for production once vuls0 is ready.

```diff
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisco-json ...
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisco-json ...
```

## Why

future-architect/vuls#2581 migrates Cisco CPE detection from go-cve-dictionary to the vuls2 boltdb. For that to work on `:latest`, the main DB must carry `cisco-json` (the extracted artifact `ghcr.io/vulsio/vuls-data-db:vuls-data-extracted-cisco-json` is already published).

## Verification

End-to-end detection was checked locally by building the main+cisco DB (nightly DB + `db add` cisco-json) and comparing `vuls report` between vuls0 master and the #2581 branch on Cisco CPEs and a RHEL host: the **detected CVE set and confidences match**; Cisco `CveContent` is a strict superset on the vuls2 side (CISCO-tagged references). No over/under-detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)