### PR TITLE
ci(db): enable paloalto-json in the main (:latest/:0) DB build

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -36,7 +36,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-nuclei-repository BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-nvd-feed-cve-v2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-oracle-linux BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-paloalto-json BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-paloalto-json BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-redhat-cve BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-redhat-vex-v1-rhel BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-rocky-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
> [!WARNING]
> **MERGE until future-architect/vuls#2589 is merged.**

## What
Uncomment `vuls-data-extracted-paloalto-json` in `db-main.mk` so the production main DB (`:0` / `:latest`) includes Palo Alto advisories.

## Why
`db-nightly.mk` already builds with `paloalto-json`; `db-main.mk` had the entry commented out. vuls is migrating Palo Alto CPE detection from go-cve-dictionary to vuls2 (future-architect/vuls#2589), which reads this DB. This mirrors the Cisco enablement (#184).

## Note
Single-line change, identical in shape to #184 (Cisco). No workflow files touched.
