### PR TITLE
ci(db): enable fortinet-csaf and fortinet-cvrf in the main DB

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -23,8 +23,8 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-exploit-inthewild BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-exploit-trickest BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fedora-api BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fortinet-csaf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fortinet-cvrf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fortinet-csaf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fortinet-cvrf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-jvn-feed-rss BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-microsoft-bulletin BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-microsoft-cvrf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
## What
Uncomment the `fortinet-csaf` and `fortinet-cvrf` `db-add` lines in `db-main.mk`, so the main (`:latest`/`:0`) DB build includes both Fortinet sources.

## Why
Both extractors are live and have been part of the nightly DB build (`db-nightly.mk`) since #187. This promotes them to the main DB.

## How
Two-line change in `db-main.mk` (uncomment), mirroring the already-active lines in `db-nightly.mk`. `BRANCH=${BRANCH}` (= `main`), consistent with the other sources. `jvn-feed-rss` and `vulncheck-nist-nvd2` are left commented (unchanged).

## Notes
Draft — to be marked ready once the nightly DB has validated the Fortinet data as expected. No workflow is triggered by this PR change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)