### PR TITLE
ci(db): enable jvn-feed-rss and vulncheck-nist-nvd2 in the main (:latest/:0) DB build

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -25,7 +25,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fedora-api BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fortinet-csaf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-fortinet-cvrf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-jvn-feed-rss BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-jvn-feed-rss BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-microsoft-bulletin BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-microsoft-cvrf BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-microsoft-msuc BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
@@ -45,7 +45,7 @@ db-build:
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-suse-oval BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-ubuntu-cve-tracker BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	# $(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-nist-nvd2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-vulncheck-nist-nvd2 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 
 .PHONY: db-add
 db-add:


### PR DESCRIPTION
## What
Uncomment the last two commented-out `db-add` lines in `db-main.mk`:
- `vuls-data-extracted-jvn-feed-rss`
- `vuls-data-extracted-vulncheck-nist-nvd2`

## Why
Both are already active in `db-nightly.mk`; this promotes them to the main (`:latest`/`:0`) DB. With this, `db-main.mk` reaches full parity with `db-nightly.mk` (36 sources, no remaining commented-out entries).

## How
Two-line change (uncomment), `BRANCH=${BRANCH}` (= `main`), consistent with the other sources. No workflow is triggered by this change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)