### PR TITLE
feat(ci/action-run-summary): link failed jobs to their log pages

### DIFF
--- a/.github/workflows/action-run-summary.yml
+++ b/.github/workflows/action-run-summary.yml
@@ -64,19 +64,19 @@ jobs:
           while IFS= read -r job_name; do
             [[ -n "$job_name" ]] || continue
             job_url=$(jq -r --arg name "$job_name" \
-              '.jobs[] | select(.name == $name) | .url' <<< "$run_json" | head -1)
+              'first(.jobs[] | select(.name == $name) | .url) // empty' <<< "$run_json")
             [[ -n "$job_url" && "$job_url" != "null" ]] || job_url="$url"
             JOB_URL["$job_name"]="$job_url"
           done <<< "$failed_jobs"
 
-          # Escape markdown link-text metacharacters ( \ [ ] ) so a job name
-          # containing them cannot break the generated link.
+          # Escape the markdown link-text metacharacters backslash, [ and ]
+          # so a job name containing them cannot break the generated link.
           md_escape() { printf '%s' "$1" | sed 's/[][\\]/\\&/g'; }
 
           # Quick-jump list linking each failed job to its log page.
           while IFS= read -r job_name; do
             [[ -n "$job_name" ]] || continue
-            echo "- [$(md_escape "$job_name")](${JOB_URL[$job_name]})" >> "$GITHUB_STEP_SUMMARY"
+            echo "- [$(md_escape "$job_name")](${JOB_URL["$job_name"]})" >> "$GITHUB_STEP_SUMMARY"
           done <<< "$failed_jobs"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
@@ -160,7 +160,7 @@ jobs:
 
           while IFS= read -r job_name; do
             # Reuse the precomputed log-page link (falls back to the run URL).
-            job_url="${JOB_URL[$job_name]:-$url}"
+            job_url="${JOB_URL["$job_name"]:-$url}"
 
             echo "---" >> "$GITHUB_STEP_SUMMARY"
             echo "#### [$(md_escape "$job_name")](${job_url})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/action-run-summary.yml
+++ b/.github/workflows/action-run-summary.yml
@@ -56,6 +56,16 @@ jobs:
           echo "### ❌ Failed jobs (${n_failed})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
+          # Quick-jump list linking each failed job to its log page.
+          while IFS= read -r job_name; do
+            [[ -n "$job_name" ]] || continue
+            job_url=$(echo "$run_json" | jq -r --arg name "$job_name" \
+              '.jobs[] | select(.name == $name) | .url' | head -1)
+            [[ -n "$job_url" && "$job_url" != "null" ]] || job_url="$url"
+            echo "- [${job_name}](${job_url})" >> "$GITHUB_STEP_SUMMARY"
+          done <<< "$failed_jobs"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
           # --- get failed logs ----------------------------------------------------
           log_file=$(mktemp)
           log_err=$(mktemp)
@@ -135,8 +145,13 @@ jobs:
           rm -f "$log_err"
 
           while IFS= read -r job_name; do
+            # Direct link to the failed job's log page (falls back to the run URL).
+            job_url=$(echo "$run_json" | jq -r --arg name "$job_name" \
+              '.jobs[] | select(.name == $name) | .url' | head -1)
+            [[ -n "$job_url" && "$job_url" != "null" ]] || job_url="$url"
+
             echo "---" >> "$GITHUB_STEP_SUMMARY"
-            echo "#### ${job_name}" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### [${job_name}](${job_url})" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
 
             if [[ ! -s "$log_file" ]]; then

--- a/.github/workflows/action-run-summary.yml
+++ b/.github/workflows/action-run-summary.yml
@@ -56,13 +56,27 @@ jobs:
           echo "### ❌ Failed jobs (${n_failed})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
+          # Build a job-name → log-URL map once, so both the quick-jump list
+          # and the per-job headings can reuse it without re-parsing run_json
+          # per failed job. Feed run_json via a here-string (not echo | jq),
+          # which preserves the JSON exactly.
+          declare -A JOB_URL
+          while IFS= read -r job_name; do
+            [[ -n "$job_name" ]] || continue
+            job_url=$(jq -r --arg name "$job_name" \
+              '.jobs[] | select(.name == $name) | .url' <<< "$run_json" | head -1)
+            [[ -n "$job_url" && "$job_url" != "null" ]] || job_url="$url"
+            JOB_URL["$job_name"]="$job_url"
+          done <<< "$failed_jobs"
+
+          # Escape markdown link-text metacharacters ( \ [ ] ) so a job name
+          # containing them cannot break the generated link.
+          md_escape() { printf '%s' "$1" | sed 's/[][\\]/\\&/g'; }
+
           # Quick-jump list linking each failed job to its log page.
           while IFS= read -r job_name; do
             [[ -n "$job_name" ]] || continue
-            job_url=$(echo "$run_json" | jq -r --arg name "$job_name" \
-              '.jobs[] | select(.name == $name) | .url' | head -1)
-            [[ -n "$job_url" && "$job_url" != "null" ]] || job_url="$url"
-            echo "- [${job_name}](${job_url})" >> "$GITHUB_STEP_SUMMARY"
+            echo "- [$(md_escape "$job_name")](${JOB_URL[$job_name]})" >> "$GITHUB_STEP_SUMMARY"
           done <<< "$failed_jobs"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
@@ -145,13 +159,11 @@ jobs:
           rm -f "$log_err"
 
           while IFS= read -r job_name; do
-            # Direct link to the failed job's log page (falls back to the run URL).
-            job_url=$(echo "$run_json" | jq -r --arg name "$job_name" \
-              '.jobs[] | select(.name == $name) | .url' | head -1)
-            [[ -n "$job_url" && "$job_url" != "null" ]] || job_url="$url"
+            # Reuse the precomputed log-page link (falls back to the run URL).
+            job_url="${JOB_URL[$job_name]:-$url}"
 
             echo "---" >> "$GITHUB_STEP_SUMMARY"
-            echo "#### [${job_name}](${job_url})" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### [$(md_escape "$job_name")](${job_url})" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
 
             if [[ ! -s "$log_file" ]]; then


### PR DESCRIPTION
## What

Add **direct links to each failed job's log page** in the Action Run Summary failure report.

- Add a quick-jump bulleted list of links to each failed job right under the "Failed jobs (N)" count.
- Turn each failed job's heading `#### <job name>` into a link: `#### [<job name>](<job log URL>)`.

The job URL comes from the `.url` field of `gh run view --json jobs`. If a job URL is unavailable, it falls back to the run URL.

## Why

Following a log from the failure report previously required manually opening the run page and hunting for the relevant job. Direct links get you to the job's log in one click.

## Test

- `actionlint`: no new warnings introduced by this change (the two remaining SC2129 style warnings pre-existed on `main`; their line numbers just shifted).
- Ran the jq link-generation logic against a real failed run and confirmed the correct per-job direct-link URLs are produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)