### PR TITLE
fix(fetch/alma-errata): restore advisories dropped by upstream

### DIFF
--- a/.github/workflows/fetch-all.yml
+++ b/.github/workflows/fetch-all.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - "alma-errata"
           - "alma-osv"
           - "alma-oval"
           - "alpine-osv"
@@ -179,6 +178,13 @@ jobs:
       packages: write
     with:
       target: ${{ matrix.target }}
+
+  fetch-alma-errata:
+    name: Fetch vuls-data-raw-alma-errata
+    uses: ./.github/workflows/fetch-alma-errata.yml
+    permissions:
+      contents: read
+      packages: write
 
   fetch-cisco-json:
     name: Fetch vuls-data-raw-cisco-json
@@ -342,6 +348,7 @@ jobs:
     needs:
       [
         fetch-main,
+        fetch-alma-errata,
         fetch-cisco-json,
         fetch-cisco-cvrf-or-csaf,
         fetch-enisa-euvd-list,

--- a/.github/workflows/fetch-alma-errata.yml
+++ b/.github/workflows/fetch-alma-errata.yml
@@ -1,0 +1,154 @@
+name: Fetch Alma (Errata)
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  fetch:
+    name: Fetch vuls-data-raw-alma-errata
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    env:
+      GOEXPERIMENT: jsonv2
+    steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
+        with:
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
+          remove-large-packages: "true"
+          remove-cached-tools: "true"
+          remove-swapfile: "true"
+
+      - name: Set global git config
+        run: |
+          git config --global gc.auto 0
+          git config --global maintenance.auto false
+          git config --global init.defaultBranch main
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: MaineK00n/vuls-data-update
+          ref: main
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install vuls-data-update
+        run: go install ./cmd/vuls-data-update
+
+      - name: Pull ghcr.io/${{ github.repository }}:vuls-data-raw-alma-errata
+        run: vuls-data-update dotgit pull --dir . --checkout main ghcr.io/${{ github.repository }}:vuls-data-raw-alma-errata
+
+      - name: Fetch
+        run: vuls-data-update fetch alma-errata --dir ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata
+
+      # AlmaLinux periodically re-curates errata.full.json and drops published
+      # advisories from the feed, while the corresponding HTML pages
+      # (https://errata.almalinux.org/10/) and the official OSV export
+      # (AlmaLinux/osv-database) keep carrying them. Observed re-curations, both
+      # AlmaLinux 10: 2025-11-26 (-102 advisories) and 2026-05-27 (-143
+      # advisories, ~376 CVEs losing coverage). Upstream inquiry:
+      # https://bugs.almalinux.org/view.php?id=644
+      #
+      # Keep this repository as the union of everything upstream has ever
+      # published (the HTML/OSV semantics): after the fetch rewrites the tree
+      # from the current feed, restore any file that a restore source still
+      # carries but the fresh fetch no longer does. Unlike paloalto-json there
+      # is no upstream list to validate against, so the check is looser: no
+      # allowlist, and upstream deletions never propagate on their own. If an
+      # advisory ever needs to be genuinely removed, delete it from the dotgit
+      # manually and it will stay gone only if it is also absent from HEAD and
+      # the pinned snapshots below.
+      - name: Restore advisories dropped from the upstream feed
+        shell: bash
+        env:
+          # Restore sources, first match wins; freshest content first.
+          #   - HEAD: the pre-fetch state (this step runs before Commit), so once
+          #     a file has been fetched or restored it stays protected.
+          #   - 8255896a: parent of e64c5ca88, the last commit carrying the 143
+          #     advisories dropped by the 2026-05-27 re-curation.
+          #   - 593d3bca: parent of cb5d6bc44, the last commit carrying the 102
+          #     advisories dropped by the 2025-11-26 re-curation.
+          # HEAD ∪ both snapshots ∪ current feed = the 511-advisory set the
+          # OSV export carries (verified 2026-07-06). The pinned snapshots only
+          # matter until their files are committed back once; after that HEAD
+          # alone keeps the union. If truncate.yml ever drops them from this
+          # tag's history the step hard-fails — re-point at commits that still
+          # carry the advisories rather than restoring nothing.
+          RESTORE_SOURCES: |
+            HEAD
+            8255896abc588ec077d76d777120a42e10197c38
+            593d3bca20cce143cc3e36a279764a604d2077c6
+        run: |
+          set -euo pipefail
+          dir="ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata"
+
+          sources=()
+          while IFS= read -r line; do
+            line="${line//[[:space:]]/}"
+            [ -n "$line" ] || continue
+            if ! git -C "$dir" rev-parse --verify -q "${line}^{commit}" >/dev/null; then
+              echo "::error::restore source ${line} is not present in $dir (gc'd out of history?); re-point RESTORE_SOURCES at a good commit"
+              exit 1
+            fi
+            sources+=("$line")
+          done <<< "${RESTORE_SOURCES}"
+
+          restored=0
+          for src in "${sources[@]}"; do
+            # Files the source carries but the fresh fetch did not write (and no
+            # earlier source has restored). List every path and filter for .json
+            # in-shell: a `-- '*.json'` pathspec would not match, since its `*`
+            # does not cross `/`, so nested advisories would be missed.
+            while IFS= read -r rel; do
+              case "$rel" in
+                *.json) ;;
+                *) continue ;;
+              esac
+              [ ! -e "$dir/$rel" ] || continue
+              # Restore to both the index and the worktree so the recovered file
+              # is committed even if the later Commit step's staging changes.
+              git -C "$dir" restore --staged --worktree --source="$src" -- "$rel"
+              echo "restored $rel from $src"
+              restored=$((restored + 1))
+            done < <(git -C "$dir" ls-tree -r --name-only "$src")
+          done
+
+          if [ "$restored" -gt 0 ]; then
+            echo "::warning::alma-errata: restored ${restored} advisory(ies) dropped from the upstream feed; if this number keeps growing across runs, upstream re-curated again (see https://bugs.almalinux.org/view.php?id=644)"
+          fi
+
+      - name: Set Git remote
+        run: |
+          if git -C ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata remote | grep -q "^origin$"; then
+            git -C ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata remote set-url origin ghcr.io/${{ github.repository }}:vuls-data-raw-alma-errata
+          else
+            git -C ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata remote add origin ghcr.io/${{ github.repository }}:vuls-data-raw-alma-errata
+          fi
+
+      - name: Commit
+        run: |
+          if [[ -n $(git -C ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata status --porcelain) ]]; then
+            git -C ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata add .
+            git -C ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata commit -m "update" -m "GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}"
+          fi
+
+      - name: Create dotgit tarball
+        run: vuls-data-update dotgit compress ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata
+
+      - name: Push ghcr.io/${{ github.repository }}:vuls-data-raw-alma-errata
+        run: vuls-data-update dotgit registry push --force --token ${{ secrets.GITHUB_TOKEN }} ghcr.io/${{ github.repository }}:vuls-data-raw-alma-errata vuls-data-raw-alma-errata.tar.zst

--- a/.github/workflows/fetch-alma-errata.yml
+++ b/.github/workflows/fetch-alma-errata.yml
@@ -64,73 +64,363 @@ jobs:
       # advisories, ~376 CVEs losing coverage). Upstream inquiry:
       # https://bugs.almalinux.org/view.php?id=644
       #
-      # Keep this repository as the union of everything upstream has ever
-      # published (the HTML/OSV semantics): after the fetch rewrites the tree
-      # from the current feed, restore any file that a restore source still
-      # carries but the fresh fetch no longer does. Unlike paloalto-json there
-      # is no upstream list to validate against, so the check is looser: no
-      # allowlist, and upstream deletions never propagate on their own. If an
-      # advisory ever needs to be genuinely removed, delete it from the dotgit
-      # manually and it will stay gone only if it is also absent from HEAD and
-      # the pinned snapshots below.
+      # After the fetch rewrites the tree from the current feed, restore exactly
+      # the advisories in RESTORE_PATHS from the pinned pre-purge snapshots, so
+      # the repository keeps carrying everything upstream ever published (the
+      # HTML/OSV semantics) without ever restoring anything unlisted. Unlike
+      # paloalto-json there is no upstream list to validate against, so the
+      # pre-fetch HEAD plays that role instead: any file that HEAD carries but
+      # the fresh fetch dropped, and that is in neither list below, fails the
+      # job. A human then triages it:
+      #   - upstream re-curated again -> append the paths to RESTORE_PATHS (and,
+      #     if the content is not in the pinned snapshots, pin the parent of the
+      #     new purge commit as an additional RESTORE_SNAPSHOTS entry);
+      #   - a genuine upstream removal that should propagate -> add the path to
+      #     ACCEPTED_REMOVAL_PATHS and drop it again once it has left HEAD.
       - name: Restore advisories dropped from the upstream feed
         shell: bash
         env:
-          # Restore sources, first match wins; freshest content first.
-          #   - HEAD: the pre-fetch state (this step runs before Commit), so once
-          #     a file has been fetched or restored it stays protected.
+          # Pre-purge snapshots to restore RESTORE_PATHS from, first match wins;
+          # freshest content first:
           #   - 8255896a: parent of e64c5ca88, the last commit carrying the 143
           #     advisories dropped by the 2026-05-27 re-curation.
           #   - 593d3bca: parent of cb5d6bc44, the last commit carrying the 102
           #     advisories dropped by the 2025-11-26 re-curation.
-          # HEAD ∪ both snapshots ∪ current feed = the 511-advisory set the
-          # OSV export carries (verified 2026-07-06). The pinned snapshots only
-          # matter until their files are committed back once; after that HEAD
-          # alone keeps the union. If truncate.yml ever drops them from this
-          # tag's history the step hard-fails — re-point at commits that still
-          # carry the advisories rather than restoring nothing.
-          RESTORE_SOURCES: |
-            HEAD
+          # If truncate.yml ever drops them from this tag's history the step
+          # hard-fails - re-point at commits that still carry the advisories
+          # rather than restoring nothing.
+          RESTORE_SNAPSHOTS: |
             8255896abc588ec077d76d777120a42e10197c38
             593d3bca20cce143cc3e36a279764a604d2077c6
+          # The 245 advisories the two re-curations dropped from the feed
+          # (current feed + these = the 511-advisory set the OSV export carries
+          # for AlmaLinux 10, verified 2026-07-06). An entry that the feed
+          # carries again emits a warning to remove it here.
+          RESTORE_PATHS: |
+            10/ALSA/2025/ALSA-2025:10073.json
+            10/ALSA/2025/ALSA-2025:10195.json
+            10/ALSA/2025/ALSA-2025:10630.json
+            10/ALSA/2025/ALSA-2025:10635.json
+            10/ALSA/2025/ALSA-2025:10873.json
+            10/ALSA/2025/ALSA-2025:11401.json
+            10/ALSA/2025/ALSA-2025:11537.json
+            10/ALSA/2025/ALSA-2025:11797.json
+            10/ALSA/2025/ALSA-2025:11888.json
+            10/ALSA/2025/ALSA-2025:11933.json
+            10/ALSA/2025/ALSA-2025:12064.json
+            10/ALSA/2025/ALSA-2025:12188.json
+            10/ALSA/2025/ALSA-2025:12850.json
+            10/ALSA/2025/ALSA-2025:13429.json
+            10/ALSA/2025/ALSA-2025:13674.json
+            10/ALSA/2025/ALSA-2025:13944.json
+            10/ALSA/2025/ALSA-2025:14137.json
+            10/ALSA/2025/ALSA-2025:14417.json
+            10/ALSA/2025/ALSA-2025:14592.json
+            10/ALSA/2025/ALSA-2025:14625.json
+            10/ALSA/2025/ALSA-2025:14844.json
+            10/ALSA/2025/ALSA-2025:15020.json
+            10/ALSA/2025/ALSA-2025:16109.json
+            10/ALSA/2025/ALSA-2025:16115.json
+            10/ALSA/2025/ALSA-2025:16157.json
+            10/ALSA/2025/ALSA-2025:16428.json
+            10/ALSA/2025/ALSA-2025:16432.json
+            10/ALSA/2025/ALSA-2025:16441.json
+            10/ALSA/2025/ALSA-2025:17119.json
+            10/ALSA/2025/ALSA-2025:17429.json
+            10/ALSA/2025/ALSA-2025:18152.json
+            10/ALSA/2025/ALSA-2025:18153.json
+            10/ALSA/2025/ALSA-2025:18154.json
+            10/ALSA/2025/ALSA-2025:18320.json
+            10/ALSA/2025/ALSA-2025:18824.json
+            10/ALSA/2025/ALSA-2025:19156.json
+            10/ALSA/2025/ALSA-2025:19403.json
+            10/ALSA/2025/ALSA-2025:19435.json
+            10/ALSA/2025/ALSA-2025:19566.json
+            10/ALSA/2025/ALSA-2025:19675.json
+            10/ALSA/2025/ALSA-2025:19772.json
+            10/ALSA/2025/ALSA-2025:20095.json
+            10/ALSA/2025/ALSA-2025:20126.json
+            10/ALSA/2025/ALSA-2025:20145.json
+            10/ALSA/2025/ALSA-2025:20155.json
+            10/ALSA/2025/ALSA-2025:20181.json
+            10/ALSA/2025/ALSA-2025:20478.json
+            10/ALSA/2025/ALSA-2025:20983.json
+            10/ALSA/2025/ALSA-2025:20998.json
+            10/ALSA/2025/ALSA-2025:21002.json
+            10/ALSA/2025/ALSA-2025:21013.json
+            10/ALSA/2025/ALSA-2025:21015.json
+            10/ALSA/2025/ALSA-2025:21030.json
+            10/ALSA/2025/ALSA-2025:21032.json
+            10/ALSA/2025/ALSA-2025:21034.json
+            10/ALSA/2025/ALSA-2025:21035.json
+            10/ALSA/2025/ALSA-2025:21142.json
+            10/ALSA/2025/ALSA-2025:21248.json
+            10/ALSA/2025/ALSA-2025:21281.json
+            10/ALSA/2025/ALSA-2025:21691.json
+            10/ALSA/2025/ALSA-2025:21843.json
+            10/ALSA/2025/ALSA-2025:21936.json
+            10/ALSA/2025/ALSA-2025:22012.json
+            10/ALSA/2025/ALSA-2025:22361.json
+            10/ALSA/2025/ALSA-2025:22394.json
+            10/ALSA/2025/ALSA-2025:23035.json
+            10/ALSA/2025/ALSA-2025:23083.json
+            10/ALSA/2025/ALSA-2025:23088.json
+            10/ALSA/2025/ALSA-2025:23294.json
+            10/ALSA/2025/ALSA-2025:23306.json
+            10/ALSA/2025/ALSA-2025:23479.json
+            10/ALSA/2025/ALSA-2025:23664.json
+            10/ALSA/2025/ALSA-2025:23667.json
+            10/ALSA/2025/ALSA-2025:23738.json
+            10/ALSA/2025/ALSA-2025:7457.json
+            10/ALSA/2025/ALSA-2025:7459.json
+            10/ALSA/2025/ALSA-2025:7462.json
+            10/ALSA/2025/ALSA-2025:7466.json
+            10/ALSA/2025/ALSA-2025:7467.json
+            10/ALSA/2025/ALSA-2025:7475.json
+            10/ALSA/2025/ALSA-2025:7476.json
+            10/ALSA/2025/ALSA-2025:7478.json
+            10/ALSA/2025/ALSA-2025:7482.json
+            10/ALSA/2025/ALSA-2025:7484.json
+            10/ALSA/2025/ALSA-2025:7489.json
+            10/ALSA/2025/ALSA-2025:7490.json
+            10/ALSA/2025/ALSA-2025:7494.json
+            10/ALSA/2025/ALSA-2025:7496.json
+            10/ALSA/2025/ALSA-2025:7497.json
+            10/ALSA/2025/ALSA-2025:7500.json
+            10/ALSA/2025/ALSA-2025:7502.json
+            10/ALSA/2025/ALSA-2025:7505.json
+            10/ALSA/2025/ALSA-2025:7506.json
+            10/ALSA/2025/ALSA-2025:7507.json
+            10/ALSA/2025/ALSA-2025:7508.json
+            10/ALSA/2025/ALSA-2025:7509.json
+            10/ALSA/2025/ALSA-2025:7510.json
+            10/ALSA/2025/ALSA-2025:7512.json
+            10/ALSA/2025/ALSA-2025:7517.json
+            10/ALSA/2025/ALSA-2025:7524.json
+            10/ALSA/2025/ALSA-2025:7592.json
+            10/ALSA/2025/ALSA-2025:7593.json
+            10/ALSA/2025/ALSA-2025:7599.json
+            10/ALSA/2025/ALSA-2025:7601.json
+            10/ALSA/2025/ALSA-2025:8047.json
+            10/ALSA/2025/ALSA-2025:8125.json
+            10/ALSA/2025/ALSA-2025:8135.json
+            10/ALSA/2025/ALSA-2025:8184.json
+            10/ALSA/2025/ALSA-2025:8196.json
+            10/ALSA/2025/ALSA-2025:8341.json
+            10/ALSA/2025/ALSA-2025:8550.json
+            10/ALSA/2025/ALSA-2025:8608.json
+            10/ALSA/2025/ALSA-2025:8636.json
+            10/ALSA/2025/ALSA-2025:8666.json
+            10/ALSA/2025/ALSA-2025:8814.json
+            10/ALSA/2025/ALSA-2025:8816.json
+            10/ALSA/2025/ALSA-2025:8915.json
+            10/ALSA/2025/ALSA-2025:9063.json
+            10/ALSA/2025/ALSA-2025:9120.json
+            10/ALSA/2025/ALSA-2025:9121.json
+            10/ALSA/2025/ALSA-2025:9148.json
+            10/ALSA/2025/ALSA-2025:9149.json
+            10/ALSA/2025/ALSA-2025:9151.json
+            10/ALSA/2025/ALSA-2025:9156.json
+            10/ALSA/2025/ALSA-2025:9304.json
+            10/ALSA/2025/ALSA-2025:9307.json
+            10/ALSA/2025/ALSA-2025:9317.json
+            10/ALSA/2025/ALSA-2025:9328.json
+            10/ALSA/2025/ALSA-2025:9418.json
+            10/ALSA/2025/ALSA-2025:9420.json
+            10/ALSA/2025/ALSA-2025:9421.json
+            10/ALSA/2025/ALSA-2025:9466.json
+            10/ALSA/2025/ALSA-2025:9623.json
+            10/ALSA/2025/ALSA-2025:A003.json
+            10/ALSA/2025/ALSA-2025:A006.json
+            10/ALSA/2026/ALSA-2026:0002.json
+            10/ALSA/2026/ALSA-2026:0025.json
+            10/ALSA/2026/ALSA-2026:0108.json
+            10/ALSA/2026/ALSA-2026:0237.json
+            10/ALSA/2026/ALSA-2026:0436.json
+            10/ALSA/2026/ALSA-2026:0594.json
+            10/ALSA/2026/ALSA-2026:0606.json
+            10/ALSA/2026/ALSA-2026:0668.json
+            10/ALSA/2026/ALSA-2026:0697.json
+            10/ALSA/2026/ALSA-2026:0770.json
+            10/ALSA/2026/ALSA-2026:0845.json
+            10/ALSA/2026/ALSA-2026:0928.json
+            10/ALSA/2026/ALSA-2026:0933.json
+            10/ALSA/2026/ALSA-2026:0975.json
+            10/ALSA/2026/ALSA-2026:10223.json
+            10/ALSA/2026/ALSA-2026:10707.json
+            10/ALSA/2026/ALSA-2026:10758.json
+            10/ALSA/2026/ALSA-2026:10767.json
+            10/ALSA/2026/ALSA-2026:11352.json
+            10/ALSA/2026/ALSA-2026:11412.json
+            10/ALSA/2026/ALSA-2026:11413.json
+            10/ALSA/2026/ALSA-2026:12265.json
+            10/ALSA/2026/ALSA-2026:12285.json
+            10/ALSA/2026/ALSA-2026:12423.json
+            10/ALSA/2026/ALSA-2026:13380.json
+            10/ALSA/2026/ALSA-2026:13498.json
+            10/ALSA/2026/ALSA-2026:13515.json
+            10/ALSA/2026/ALSA-2026:13641.json
+            10/ALSA/2026/ALSA-2026:13642.json
+            10/ALSA/2026/ALSA-2026:13643.json
+            10/ALSA/2026/ALSA-2026:13644.json
+            10/ALSA/2026/ALSA-2026:1472.json
+            10/ALSA/2026/ALSA-2026:14790.json
+            10/ALSA/2026/ALSA-2026:15888.json
+            10/ALSA/2026/ALSA-2026:15969.json
+            10/ALSA/2026/ALSA-2026:1597.json
+            10/ALSA/2026/ALSA-2026:16014.json
+            10/ALSA/2026/ALSA-2026:1628.json
+            10/ALSA/2026/ALSA-2026:16692.json
+            10/ALSA/2026/ALSA-2026:1696.json
+            10/ALSA/2026/ALSA-2026:17075.json
+            10/ALSA/2026/ALSA-2026:1714.json
+            10/ALSA/2026/ALSA-2026:1715.json
+            10/ALSA/2026/ALSA-2026:18064.json
+            10/ALSA/2026/ALSA-2026:1825.json
+            10/ALSA/2026/ALSA-2026:1831.json
+            10/ALSA/2026/ALSA-2026:1837.json
+            10/ALSA/2026/ALSA-2026:1838.json
+            10/ALSA/2026/ALSA-2026:1907.json
+            10/ALSA/2026/ALSA-2026:2222.json
+            10/ALSA/2026/ALSA-2026:2230.json
+            10/ALSA/2026/ALSA-2026:2271.json
+            10/ALSA/2026/ALSA-2026:2286.json
+            10/ALSA/2026/ALSA-2026:2719.json
+            10/ALSA/2026/ALSA-2026:2914.json
+            10/ALSA/2026/ALSA-2026:3033.json
+            10/ALSA/2026/ALSA-2026:3035.json
+            10/ALSA/2026/ALSA-2026:3068.json
+            10/ALSA/2026/ALSA-2026:3092.json
+            10/ALSA/2026/ALSA-2026:3094.json
+            10/ALSA/2026/ALSA-2026:3297.json
+            10/ALSA/2026/ALSA-2026:3343.json
+            10/ALSA/2026/ALSA-2026:3361.json
+            10/ALSA/2026/ALSA-2026:3443.json
+            10/ALSA/2026/ALSA-2026:3476.json
+            10/ALSA/2026/ALSA-2026:3477.json
+            10/ALSA/2026/ALSA-2026:3517.json
+            10/ALSA/2026/ALSA-2026:3551.json
+            10/ALSA/2026/ALSA-2026:3752.json
+            10/ALSA/2026/ALSA-2026:3840.json
+            10/ALSA/2026/ALSA-2026:3864.json
+            10/ALSA/2026/ALSA-2026:3939.json
+            10/ALSA/2026/ALSA-2026:4164.json
+            10/ALSA/2026/ALSA-2026:4174.json
+            10/ALSA/2026/ALSA-2026:4450.json
+            10/ALSA/2026/ALSA-2026:4451.json
+            10/ALSA/2026/ALSA-2026:4453.json
+            10/ALSA/2026/ALSA-2026:4629.json
+            10/ALSA/2026/ALSA-2026:4717.json
+            10/ALSA/2026/ALSA-2026:5063.json
+            10/ALSA/2026/ALSA-2026:5145.json
+            10/ALSA/2026/ALSA-2026:5146.json
+            10/ALSA/2026/ALSA-2026:5931.json
+            10/ALSA/2026/ALSA-2026:5939.json
+            10/ALSA/2026/ALSA-2026:6259.json
+            10/ALSA/2026/ALSA-2026:6342.json
+            10/ALSA/2026/ALSA-2026:6344.json
+            10/ALSA/2026/ALSA-2026:6388.json
+            10/ALSA/2026/ALSA-2026:6463.json
+            10/ALSA/2026/ALSA-2026:6622.json
+            10/ALSA/2026/ALSA-2026:6631.json
+            10/ALSA/2026/ALSA-2026:6799.json
+            10/ALSA/2026/ALSA-2026:7005.json
+            10/ALSA/2026/ALSA-2026:7081.json
+            10/ALSA/2026/ALSA-2026:7666.json
+            10/ALSA/2026/ALSA-2026:7672.json
+            10/ALSA/2026/ALSA-2026:7680.json
+            10/ALSA/2026/ALSA-2026:7682.json
+            10/ALSA/2026/ALSA-2026:7992.json
+            10/ALSA/2026/ALSA-2026:8119.json
+            10/ALSA/2026/ALSA-2026:8458.json
+            10/ALSA/2026/ALSA-2026:8470.json
+            10/ALSA/2026/ALSA-2026:8472.json
+            10/ALSA/2026/ALSA-2026:8492.json
+            10/ALSA/2026/ALSA-2026:8842.json
+            10/ALSA/2026/ALSA-2026:8858.json
+            10/ALSA/2026/ALSA-2026:9638.json
+            10/ALSA/2026/ALSA-2026:9666.json
+            10/ALSA/2026/ALSA-2026:9689.json
+            10/ALSA/2026/ALSA-2026:9693.json
+          # Feed removals a human has accepted as genuine; the guard lets these
+          # deletions propagate instead of failing. Remove an entry once the
+          # file has left HEAD.
+          ACCEPTED_REMOVAL_PATHS: ""
         run: |
           set -euo pipefail
           dir="ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata"
 
-          sources=()
+          snapshots=()
           while IFS= read -r line; do
             line="${line//[[:space:]]/}"
             [ -n "$line" ] || continue
             if ! git -C "$dir" rev-parse --verify -q "${line}^{commit}" >/dev/null; then
-              echo "::error::restore source ${line} is not present in $dir (gc'd out of history?); re-point RESTORE_SOURCES at a good commit"
+              echo "::error::restore snapshot ${line} is not present in $dir (gc'd out of history?); re-point RESTORE_SNAPSHOTS at a good commit"
               exit 1
             fi
-            sources+=("$line")
-          done <<< "${RESTORE_SOURCES}"
+            snapshots+=("$line")
+          done <<< "${RESTORE_SNAPSHOTS}"
+
+          declare -A restore accepted
+          while IFS= read -r line; do
+            line="${line//[[:space:]]/}"
+            [ -n "$line" ] || continue
+            restore["$line"]=1
+          done <<< "${RESTORE_PATHS}"
+          while IFS= read -r line; do
+            line="${line//[[:space:]]/}"
+            [ -n "$line" ] || continue
+            accepted["$line"]=1
+          done <<< "${ACCEPTED_REMOVAL_PATHS}"
+
+          # Unexpected drop: carried by the pre-fetch HEAD (this step runs
+          # before Commit), missing from the fresh fetch, in neither list.
+          # Fail fast - if this trips the run is dying regardless, so don't
+          # restore first.
+          unexpected=()
+          while IFS= read -r rel; do
+            case "$rel" in
+              *.json) ;;
+              *) continue ;;
+            esac
+            [ ! -e "$dir/$rel" ] || continue
+            [ -z "${restore[$rel]:-}" ] || continue
+            [ -z "${accepted[$rel]:-}" ] || continue
+            unexpected+=("$rel")
+          done < <(git -C "$dir" ls-tree -r --name-only HEAD)
+          if [ "${#unexpected[@]}" -gt 0 ]; then
+            printf '::error::alma-errata: %d advisory(ies) dropped from the feed but not in RESTORE_PATHS / ACCEPTED_REMOVAL_PATHS: %s\n' "${#unexpected[@]}" "${unexpected[*]}"
+            echo "If upstream re-curated again, add them to RESTORE_PATHS; if the removals are genuine, add them to ACCEPTED_REMOVAL_PATHS."
+            exit 1
+          fi
 
           restored=0
-          for src in "${sources[@]}"; do
-            # Files the source carries but the fresh fetch did not write (and no
-            # earlier source has restored). List every path and filter for .json
-            # in-shell: a `-- '*.json'` pathspec would not match, since its `*`
-            # does not cross `/`, so nested advisories would be missed.
-            while IFS= read -r rel; do
-              case "$rel" in
-                *.json) ;;
-                *) continue ;;
-              esac
-              [ ! -e "$dir/$rel" ] || continue
-              # Restore to both the index and the worktree so the recovered file
-              # is committed even if the later Commit step's staging changes.
-              git -C "$dir" restore --staged --worktree --source="$src" -- "$rel"
-              echo "restored $rel from $src"
-              restored=$((restored + 1))
-            done < <(git -C "$dir" ls-tree -r --name-only "$src")
+          for rel in "${!restore[@]}"; do
+            if [ -e "$dir/$rel" ]; then
+              echo "::warning::alma-errata ${rel}: carried by the feed again; remove it from RESTORE_PATHS."
+              continue
+            fi
+            src=""
+            for snap in "${snapshots[@]}"; do
+              if git -C "$dir" cat-file -e "${snap}:${rel}" 2>/dev/null; then
+                src="$snap"
+                break
+              fi
+            done
+            if [ -z "$src" ]; then
+              # Listed for restore yet present in no snapshot: we cannot keep
+              # the dataset complete -> fail, don't commit a silently-incomplete
+              # tree.
+              echo "::error::alma-errata ${rel}: in RESTORE_PATHS but absent from every RESTORE_SNAPSHOTS entry; cannot restore (dataset would be incomplete)."
+              exit 1
+            fi
+            # Restore to both the index and the worktree so the recovered file
+            # is committed even if the later Commit step's staging changes.
+            git -C "$dir" restore --staged --worktree --source="$src" -- "$rel"
+            restored=$((restored + 1))
           done
 
-          if [ "$restored" -gt 0 ]; then
-            echo "::warning::alma-errata: restored ${restored} advisory(ies) dropped from the upstream feed; if this number keeps growing across runs, upstream re-curated again (see https://bugs.almalinux.org/view.php?id=644)"
-          fi
+          echo "restored ${restored} advisory(ies) from pinned snapshots"
 
       - name: Set Git remote
         run: |

--- a/.github/workflows/fetch-alma-errata.yml
+++ b/.github/workflows/fetch-alma-errata.yml
@@ -65,22 +65,22 @@ jobs:
       # https://bugs.almalinux.org/view.php?id=644
       #
       # After the fetch rewrites the tree from the current feed, restore exactly
-      # the advisories in RESTORE_PATHS from the pinned pre-purge snapshots, so
-      # the repository keeps carrying everything upstream still publishes (the
-      # HTML/OSV semantics) without ever restoring anything unlisted.
+      # the advisories listed below, each from the pinned pre-purge snapshot its
+      # list block declares (RESTORE_SNAPSHOT_N / RESTORE_PATHS_N pairs; for a
+      # future re-curation, append a new pair pinning the parent of the new
+      # purge commit). Nothing unlisted is ever restored, and every file's
+      # source commit is explicit in this file.
       #
       # The per-version HTML directory index (one GET per version) is the
       # oracle for whether upstream still publishes an advisory:
       #   - a file the pre-fetch HEAD carries but the fresh fetch dropped, and
-      #     that is not in RESTORE_PATHS: still in the index -> feed
-      #     re-curation, fail so a human appends it to RESTORE_PATHS (and, if
-      #     its content is in no pinned snapshot, pins the parent of the new
-      #     purge commit as an additional RESTORE_SNAPSHOTS entry); gone from
+      #     that no list declares: still in the index -> feed re-curation,
+      #     fail so a human appends it to a RESTORE_PATHS_N block; gone from
       #     the index -> genuine upstream retirement, let the deletion
       #     propagate with a warning.
-      #   - a RESTORE_PATHS entry about to be restored that is gone from the
-      #     index -> upstream retired it for real; fail so a human removes the
-      #     entry (removing it is the explicit acceptance of the retirement).
+      #   - a listed entry about to be restored that is gone from the index ->
+      #     upstream retired it for real; fail so a human removes the entry
+      #     (removing it is the explicit acceptance of the retirement).
       # The index is served by the same host the Fetch step just read the feed
       # from, so this adds no new availability dependency; an unreachable or
       # unparsable index fails the job rather than guessing.
@@ -88,64 +88,13 @@ jobs:
         shell: bash
         env:
           ERRATA_HTML_BASE: https://errata.almalinux.org
-          # Pre-purge snapshots to restore RESTORE_PATHS from, first match wins;
-          # freshest content first:
-          #   - 8255896a: parent of e64c5ca88, the last commit carrying the 143
-          #     advisories dropped by the 2026-05-27 re-curation.
-          #   - 593d3bca: parent of cb5d6bc44, the last commit carrying the 102
-          #     advisories dropped by the 2025-11-26 re-curation.
-          # If truncate.yml ever drops them from this tag's history the step
-          # hard-fails - re-point at commits that still carry the advisories
-          # rather than restoring nothing.
-          RESTORE_SNAPSHOTS: |
-            8255896abc588ec077d76d777120a42e10197c38
-            593d3bca20cce143cc3e36a279764a604d2077c6
-          # The 245 advisories the two re-curations dropped from the feed
-          # (current feed + these = the 511-advisory set the OSV export and the
-          # HTML index carry, verified 2026-07-06). An entry that the feed
-          # carries again emits a warning to remove it here.
-          RESTORE_PATHS: |
-            10/ALSA/2025/ALSA-2025:10073.json
-            10/ALSA/2025/ALSA-2025:10195.json
-            10/ALSA/2025/ALSA-2025:10630.json
-            10/ALSA/2025/ALSA-2025:10635.json
-            10/ALSA/2025/ALSA-2025:10873.json
-            10/ALSA/2025/ALSA-2025:11401.json
-            10/ALSA/2025/ALSA-2025:11537.json
-            10/ALSA/2025/ALSA-2025:11797.json
-            10/ALSA/2025/ALSA-2025:11888.json
-            10/ALSA/2025/ALSA-2025:11933.json
-            10/ALSA/2025/ALSA-2025:12064.json
-            10/ALSA/2025/ALSA-2025:12188.json
-            10/ALSA/2025/ALSA-2025:12850.json
-            10/ALSA/2025/ALSA-2025:13429.json
-            10/ALSA/2025/ALSA-2025:13674.json
-            10/ALSA/2025/ALSA-2025:13944.json
-            10/ALSA/2025/ALSA-2025:14137.json
-            10/ALSA/2025/ALSA-2025:14417.json
-            10/ALSA/2025/ALSA-2025:14592.json
-            10/ALSA/2025/ALSA-2025:14625.json
-            10/ALSA/2025/ALSA-2025:14844.json
-            10/ALSA/2025/ALSA-2025:15020.json
-            10/ALSA/2025/ALSA-2025:16109.json
-            10/ALSA/2025/ALSA-2025:16115.json
-            10/ALSA/2025/ALSA-2025:16157.json
-            10/ALSA/2025/ALSA-2025:16428.json
-            10/ALSA/2025/ALSA-2025:16432.json
-            10/ALSA/2025/ALSA-2025:16441.json
-            10/ALSA/2025/ALSA-2025:17119.json
-            10/ALSA/2025/ALSA-2025:17429.json
-            10/ALSA/2025/ALSA-2025:18152.json
-            10/ALSA/2025/ALSA-2025:18153.json
-            10/ALSA/2025/ALSA-2025:18154.json
-            10/ALSA/2025/ALSA-2025:18320.json
-            10/ALSA/2025/ALSA-2025:18824.json
-            10/ALSA/2025/ALSA-2025:19156.json
-            10/ALSA/2025/ALSA-2025:19403.json
-            10/ALSA/2025/ALSA-2025:19435.json
-            10/ALSA/2025/ALSA-2025:19566.json
-            10/ALSA/2025/ALSA-2025:19675.json
-            10/ALSA/2025/ALSA-2025:19772.json
+          # Parent of e64c5ca88, the last commit carrying the 143 advisories
+          # dropped by the 2026-05-27 re-curation. If truncate.yml ever drops a
+          # snapshot from this tag's history the step hard-fails - re-point at
+          # a commit that still carries the advisories rather than restoring
+          # nothing.
+          RESTORE_SNAPSHOT_1: 8255896abc588ec077d76d777120a42e10197c38
+          RESTORE_PATHS_1: |
             10/ALSA/2025/ALSA-2025:20095.json
             10/ALSA/2025/ALSA-2025:20126.json
             10/ALSA/2025/ALSA-2025:20145.json
@@ -179,67 +128,6 @@ jobs:
             10/ALSA/2025/ALSA-2025:23664.json
             10/ALSA/2025/ALSA-2025:23667.json
             10/ALSA/2025/ALSA-2025:23738.json
-            10/ALSA/2025/ALSA-2025:7457.json
-            10/ALSA/2025/ALSA-2025:7459.json
-            10/ALSA/2025/ALSA-2025:7462.json
-            10/ALSA/2025/ALSA-2025:7466.json
-            10/ALSA/2025/ALSA-2025:7467.json
-            10/ALSA/2025/ALSA-2025:7475.json
-            10/ALSA/2025/ALSA-2025:7476.json
-            10/ALSA/2025/ALSA-2025:7478.json
-            10/ALSA/2025/ALSA-2025:7482.json
-            10/ALSA/2025/ALSA-2025:7484.json
-            10/ALSA/2025/ALSA-2025:7489.json
-            10/ALSA/2025/ALSA-2025:7490.json
-            10/ALSA/2025/ALSA-2025:7494.json
-            10/ALSA/2025/ALSA-2025:7496.json
-            10/ALSA/2025/ALSA-2025:7497.json
-            10/ALSA/2025/ALSA-2025:7500.json
-            10/ALSA/2025/ALSA-2025:7502.json
-            10/ALSA/2025/ALSA-2025:7505.json
-            10/ALSA/2025/ALSA-2025:7506.json
-            10/ALSA/2025/ALSA-2025:7507.json
-            10/ALSA/2025/ALSA-2025:7508.json
-            10/ALSA/2025/ALSA-2025:7509.json
-            10/ALSA/2025/ALSA-2025:7510.json
-            10/ALSA/2025/ALSA-2025:7512.json
-            10/ALSA/2025/ALSA-2025:7517.json
-            10/ALSA/2025/ALSA-2025:7524.json
-            10/ALSA/2025/ALSA-2025:7592.json
-            10/ALSA/2025/ALSA-2025:7593.json
-            10/ALSA/2025/ALSA-2025:7599.json
-            10/ALSA/2025/ALSA-2025:7601.json
-            10/ALSA/2025/ALSA-2025:8047.json
-            10/ALSA/2025/ALSA-2025:8125.json
-            10/ALSA/2025/ALSA-2025:8135.json
-            10/ALSA/2025/ALSA-2025:8184.json
-            10/ALSA/2025/ALSA-2025:8196.json
-            10/ALSA/2025/ALSA-2025:8341.json
-            10/ALSA/2025/ALSA-2025:8550.json
-            10/ALSA/2025/ALSA-2025:8608.json
-            10/ALSA/2025/ALSA-2025:8636.json
-            10/ALSA/2025/ALSA-2025:8666.json
-            10/ALSA/2025/ALSA-2025:8814.json
-            10/ALSA/2025/ALSA-2025:8816.json
-            10/ALSA/2025/ALSA-2025:8915.json
-            10/ALSA/2025/ALSA-2025:9063.json
-            10/ALSA/2025/ALSA-2025:9120.json
-            10/ALSA/2025/ALSA-2025:9121.json
-            10/ALSA/2025/ALSA-2025:9148.json
-            10/ALSA/2025/ALSA-2025:9149.json
-            10/ALSA/2025/ALSA-2025:9151.json
-            10/ALSA/2025/ALSA-2025:9156.json
-            10/ALSA/2025/ALSA-2025:9304.json
-            10/ALSA/2025/ALSA-2025:9307.json
-            10/ALSA/2025/ALSA-2025:9317.json
-            10/ALSA/2025/ALSA-2025:9328.json
-            10/ALSA/2025/ALSA-2025:9418.json
-            10/ALSA/2025/ALSA-2025:9420.json
-            10/ALSA/2025/ALSA-2025:9421.json
-            10/ALSA/2025/ALSA-2025:9466.json
-            10/ALSA/2025/ALSA-2025:9623.json
-            10/ALSA/2025/ALSA-2025:A003.json
-            10/ALSA/2025/ALSA-2025:A006.json
             10/ALSA/2026/ALSA-2026:0002.json
             10/ALSA/2026/ALSA-2026:0025.json
             10/ALSA/2026/ALSA-2026:0108.json
@@ -350,30 +238,143 @@ jobs:
             10/ALSA/2026/ALSA-2026:9666.json
             10/ALSA/2026/ALSA-2026:9689.json
             10/ALSA/2026/ALSA-2026:9693.json
+          # Parent of cb5d6bc44, the last commit carrying the 102 advisories
+          # dropped by the 2025-11-26 re-curation.
+          RESTORE_SNAPSHOT_2: 593d3bca20cce143cc3e36a279764a604d2077c6
+          RESTORE_PATHS_2: |
+            10/ALSA/2025/ALSA-2025:10073.json
+            10/ALSA/2025/ALSA-2025:10195.json
+            10/ALSA/2025/ALSA-2025:10630.json
+            10/ALSA/2025/ALSA-2025:10635.json
+            10/ALSA/2025/ALSA-2025:10873.json
+            10/ALSA/2025/ALSA-2025:11401.json
+            10/ALSA/2025/ALSA-2025:11537.json
+            10/ALSA/2025/ALSA-2025:11797.json
+            10/ALSA/2025/ALSA-2025:11888.json
+            10/ALSA/2025/ALSA-2025:11933.json
+            10/ALSA/2025/ALSA-2025:12064.json
+            10/ALSA/2025/ALSA-2025:12188.json
+            10/ALSA/2025/ALSA-2025:12850.json
+            10/ALSA/2025/ALSA-2025:13429.json
+            10/ALSA/2025/ALSA-2025:13674.json
+            10/ALSA/2025/ALSA-2025:13944.json
+            10/ALSA/2025/ALSA-2025:14137.json
+            10/ALSA/2025/ALSA-2025:14417.json
+            10/ALSA/2025/ALSA-2025:14592.json
+            10/ALSA/2025/ALSA-2025:14625.json
+            10/ALSA/2025/ALSA-2025:14844.json
+            10/ALSA/2025/ALSA-2025:15020.json
+            10/ALSA/2025/ALSA-2025:16109.json
+            10/ALSA/2025/ALSA-2025:16115.json
+            10/ALSA/2025/ALSA-2025:16157.json
+            10/ALSA/2025/ALSA-2025:16428.json
+            10/ALSA/2025/ALSA-2025:16432.json
+            10/ALSA/2025/ALSA-2025:16441.json
+            10/ALSA/2025/ALSA-2025:17119.json
+            10/ALSA/2025/ALSA-2025:17429.json
+            10/ALSA/2025/ALSA-2025:18152.json
+            10/ALSA/2025/ALSA-2025:18153.json
+            10/ALSA/2025/ALSA-2025:18154.json
+            10/ALSA/2025/ALSA-2025:18320.json
+            10/ALSA/2025/ALSA-2025:18824.json
+            10/ALSA/2025/ALSA-2025:19156.json
+            10/ALSA/2025/ALSA-2025:19403.json
+            10/ALSA/2025/ALSA-2025:19435.json
+            10/ALSA/2025/ALSA-2025:19566.json
+            10/ALSA/2025/ALSA-2025:19675.json
+            10/ALSA/2025/ALSA-2025:19772.json
+            10/ALSA/2025/ALSA-2025:7457.json
+            10/ALSA/2025/ALSA-2025:7459.json
+            10/ALSA/2025/ALSA-2025:7462.json
+            10/ALSA/2025/ALSA-2025:7466.json
+            10/ALSA/2025/ALSA-2025:7467.json
+            10/ALSA/2025/ALSA-2025:7475.json
+            10/ALSA/2025/ALSA-2025:7476.json
+            10/ALSA/2025/ALSA-2025:7478.json
+            10/ALSA/2025/ALSA-2025:7482.json
+            10/ALSA/2025/ALSA-2025:7484.json
+            10/ALSA/2025/ALSA-2025:7489.json
+            10/ALSA/2025/ALSA-2025:7490.json
+            10/ALSA/2025/ALSA-2025:7494.json
+            10/ALSA/2025/ALSA-2025:7496.json
+            10/ALSA/2025/ALSA-2025:7497.json
+            10/ALSA/2025/ALSA-2025:7500.json
+            10/ALSA/2025/ALSA-2025:7502.json
+            10/ALSA/2025/ALSA-2025:7505.json
+            10/ALSA/2025/ALSA-2025:7506.json
+            10/ALSA/2025/ALSA-2025:7507.json
+            10/ALSA/2025/ALSA-2025:7508.json
+            10/ALSA/2025/ALSA-2025:7509.json
+            10/ALSA/2025/ALSA-2025:7510.json
+            10/ALSA/2025/ALSA-2025:7512.json
+            10/ALSA/2025/ALSA-2025:7517.json
+            10/ALSA/2025/ALSA-2025:7524.json
+            10/ALSA/2025/ALSA-2025:7592.json
+            10/ALSA/2025/ALSA-2025:7593.json
+            10/ALSA/2025/ALSA-2025:7599.json
+            10/ALSA/2025/ALSA-2025:7601.json
+            10/ALSA/2025/ALSA-2025:8047.json
+            10/ALSA/2025/ALSA-2025:8125.json
+            10/ALSA/2025/ALSA-2025:8135.json
+            10/ALSA/2025/ALSA-2025:8184.json
+            10/ALSA/2025/ALSA-2025:8196.json
+            10/ALSA/2025/ALSA-2025:8341.json
+            10/ALSA/2025/ALSA-2025:8550.json
+            10/ALSA/2025/ALSA-2025:8608.json
+            10/ALSA/2025/ALSA-2025:8636.json
+            10/ALSA/2025/ALSA-2025:8666.json
+            10/ALSA/2025/ALSA-2025:8814.json
+            10/ALSA/2025/ALSA-2025:8816.json
+            10/ALSA/2025/ALSA-2025:8915.json
+            10/ALSA/2025/ALSA-2025:9063.json
+            10/ALSA/2025/ALSA-2025:9120.json
+            10/ALSA/2025/ALSA-2025:9121.json
+            10/ALSA/2025/ALSA-2025:9148.json
+            10/ALSA/2025/ALSA-2025:9149.json
+            10/ALSA/2025/ALSA-2025:9151.json
+            10/ALSA/2025/ALSA-2025:9156.json
+            10/ALSA/2025/ALSA-2025:9304.json
+            10/ALSA/2025/ALSA-2025:9307.json
+            10/ALSA/2025/ALSA-2025:9317.json
+            10/ALSA/2025/ALSA-2025:9328.json
+            10/ALSA/2025/ALSA-2025:9418.json
+            10/ALSA/2025/ALSA-2025:9420.json
+            10/ALSA/2025/ALSA-2025:9421.json
+            10/ALSA/2025/ALSA-2025:9466.json
+            10/ALSA/2025/ALSA-2025:9623.json
+            10/ALSA/2025/ALSA-2025:A003.json
+            10/ALSA/2025/ALSA-2025:A006.json
         run: |
           set -euo pipefail
           dir="ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata"
 
-          snapshots=()
-          while IFS= read -r line; do
-            line="${line//[[:space:]]/}"
-            [ -n "$line" ] || continue
-            if ! git -C "$dir" rev-parse --verify -q "${line}^{commit}" >/dev/null; then
-              echo "::error::restore snapshot ${line} is not present in $dir (gc'd out of history?); re-point RESTORE_SNAPSHOTS at a good commit"
+          # src[<path>] = the snapshot commit its list block declares.
+          declare -A src
+          i=1
+          while :; do
+            snapvar="RESTORE_SNAPSHOT_${i}"
+            pathsvar="RESTORE_PATHS_${i}"
+            snap="${!snapvar:-}"
+            [ -n "$snap" ] || break
+            snap="${snap//[[:space:]]/}"
+            if ! git -C "$dir" rev-parse --verify -q "${snap}^{commit}" >/dev/null; then
+              echo "::error::restore snapshot ${snap} (${snapvar}) is not present in $dir (gc'd out of history?); re-point it at a good commit"
               exit 1
             fi
-            snapshots+=("$line")
-          done <<< "${RESTORE_SNAPSHOTS}"
-
-          declare -A restore
-          while IFS= read -r line; do
-            line="${line//[[:space:]]/}"
-            [ -n "$line" ] || continue
-            restore["$line"]=1
-          done <<< "${RESTORE_PATHS}"
+            while IFS= read -r line; do
+              line="${line//[[:space:]]/}"
+              [ -n "$line" ] || continue
+              if [ -n "${src[$line]:-}" ]; then
+                echo "::error::alma-errata ${line}: listed under more than one RESTORE_PATHS_N block; keep exactly one entry per path"
+                exit 1
+              fi
+              src["$line"]="$snap"
+            done <<< "${!pathsvar:-}"
+            i=$((i + 1))
+          done
 
           # Files the pre-fetch HEAD carries (this step runs before Commit)
-          # that the fresh fetch did not write and RESTORE_PATHS does not list.
+          # that the fresh fetch did not write and no list block declares.
           dropped=()
           while IFS= read -r rel; do
             case "$rel" in
@@ -381,7 +382,7 @@ jobs:
               *) continue ;;
             esac
             [ ! -e "$dir/$rel" ] || continue
-            [ -z "${restore[$rel]:-}" ] || continue
+            [ -z "${src[$rel]:-}" ] || continue
             dropped+=("$rel")
           done < <(git -C "$dir" ls-tree -r --name-only HEAD)
 
@@ -391,7 +392,7 @@ jobs:
           # that parses to zero entries likewise.
           declare -A html versions
           for rel in "${dropped[@]:+"${dropped[@]}"}"; do versions["${rel%%/*}"]=1; done
-          for rel in "${!restore[@]}"; do [ -e "$dir/$rel" ] || versions["${rel%%/*}"]=1; done
+          for rel in "${!src[@]}"; do [ -e "$dir/$rel" ] || versions["${rel%%/*}"]=1; done
           for v in "${!versions[@]}"; do
             n=0
             while IFS= read -r f; do
@@ -419,39 +420,33 @@ jobs:
           done
           if [ "${#unexpected[@]}" -gt 0 ]; then
             printf '::error::alma-errata: %d advisory(ies) dropped from the feed while their HTML pages are still published: %s\n' "${#unexpected[@]}" "${unexpected[*]}"
-            echo "Upstream re-curated the feed again; add them to RESTORE_PATHS (see https://bugs.almalinux.org/view.php?id=644)."
+            echo "Upstream re-curated the feed again; add them to a RESTORE_PATHS_N block (see https://bugs.almalinux.org/view.php?id=644)."
             exit 1
           fi
 
           restored=0
-          for rel in "${!restore[@]}"; do
+          for rel in "${!src[@]}"; do
             if [ -e "$dir/$rel" ]; then
-              echo "::warning::alma-errata ${rel}: carried by the feed again; remove it from RESTORE_PATHS."
+              echo "::warning::alma-errata ${rel}: carried by the feed again; remove it from its RESTORE_PATHS_N block."
               continue
             fi
             v="${rel%%/*}"
             base="$(basename "$rel" .json)"
             if [ -z "${html[$v/${base//:/-}.html]:-}" ]; then
-              echo "::error::alma-errata ${rel}: in RESTORE_PATHS but upstream retired it (HTML page gone); remove the entry to accept the retirement."
+              echo "::error::alma-errata ${rel}: listed for restore but upstream retired it (HTML page gone); remove the entry to accept the retirement."
               exit 1
             fi
-            src=""
-            for snap in "${snapshots[@]}"; do
-              if git -C "$dir" cat-file -e "${snap}:${rel}" 2>/dev/null; then
-                src="$snap"
-                break
-              fi
-            done
-            if [ -z "$src" ]; then
-              # Listed for restore yet present in no snapshot: we cannot keep
-              # the dataset complete -> fail, don't commit a silently-incomplete
-              # tree.
-              echo "::error::alma-errata ${rel}: in RESTORE_PATHS but absent from every RESTORE_SNAPSHOTS entry; cannot restore (dataset would be incomplete)."
+            snap="${src[$rel]}"
+            if ! git -C "$dir" cat-file -e "${snap}:${rel}" 2>/dev/null; then
+              # Listed under a snapshot that does not carry it: the list is
+              # wrong and we cannot keep the dataset complete -> fail, don't
+              # commit a silently-incomplete tree.
+              echo "::error::alma-errata ${rel}: declared under snapshot ${snap} but absent from it; fix the RESTORE_PATHS_N assignment."
               exit 1
             fi
             # Restore to both the index and the worktree so the recovered file
             # is committed even if the later Commit step's staging changes.
-            git -C "$dir" restore --staged --worktree --source="$src" -- "$rel"
+            git -C "$dir" restore --staged --worktree --source="$snap" -- "$rel"
             restored=$((restored + 1))
           done
 

--- a/.github/workflows/fetch-alma-errata.yml
+++ b/.github/workflows/fetch-alma-errata.yml
@@ -66,20 +66,28 @@ jobs:
       #
       # After the fetch rewrites the tree from the current feed, restore exactly
       # the advisories in RESTORE_PATHS from the pinned pre-purge snapshots, so
-      # the repository keeps carrying everything upstream ever published (the
-      # HTML/OSV semantics) without ever restoring anything unlisted. Unlike
-      # paloalto-json there is no upstream list to validate against, so the
-      # pre-fetch HEAD plays that role instead: any file that HEAD carries but
-      # the fresh fetch dropped, and that is in neither list below, fails the
-      # job. A human then triages it:
-      #   - upstream re-curated again -> append the paths to RESTORE_PATHS (and,
-      #     if the content is not in the pinned snapshots, pin the parent of the
-      #     new purge commit as an additional RESTORE_SNAPSHOTS entry);
-      #   - a genuine upstream removal that should propagate -> add the path to
-      #     ACCEPTED_REMOVAL_PATHS and drop it again once it has left HEAD.
+      # the repository keeps carrying everything upstream still publishes (the
+      # HTML/OSV semantics) without ever restoring anything unlisted.
+      #
+      # The per-version HTML directory index (one GET per version) is the
+      # oracle for whether upstream still publishes an advisory:
+      #   - a file the pre-fetch HEAD carries but the fresh fetch dropped, and
+      #     that is not in RESTORE_PATHS: still in the index -> feed
+      #     re-curation, fail so a human appends it to RESTORE_PATHS (and, if
+      #     its content is in no pinned snapshot, pins the parent of the new
+      #     purge commit as an additional RESTORE_SNAPSHOTS entry); gone from
+      #     the index -> genuine upstream retirement, let the deletion
+      #     propagate with a warning.
+      #   - a RESTORE_PATHS entry about to be restored that is gone from the
+      #     index -> upstream retired it for real; fail so a human removes the
+      #     entry (removing it is the explicit acceptance of the retirement).
+      # The index is served by the same host the Fetch step just read the feed
+      # from, so this adds no new availability dependency; an unreachable or
+      # unparsable index fails the job rather than guessing.
       - name: Restore advisories dropped from the upstream feed
         shell: bash
         env:
+          ERRATA_HTML_BASE: https://errata.almalinux.org
           # Pre-purge snapshots to restore RESTORE_PATHS from, first match wins;
           # freshest content first:
           #   - 8255896a: parent of e64c5ca88, the last commit carrying the 143
@@ -93,8 +101,8 @@ jobs:
             8255896abc588ec077d76d777120a42e10197c38
             593d3bca20cce143cc3e36a279764a604d2077c6
           # The 245 advisories the two re-curations dropped from the feed
-          # (current feed + these = the 511-advisory set the OSV export carries
-          # for AlmaLinux 10, verified 2026-07-06). An entry that the feed
+          # (current feed + these = the 511-advisory set the OSV export and the
+          # HTML index carry, verified 2026-07-06). An entry that the feed
           # carries again emits a warning to remove it here.
           RESTORE_PATHS: |
             10/ALSA/2025/ALSA-2025:10073.json
@@ -342,10 +350,6 @@ jobs:
             10/ALSA/2026/ALSA-2026:9666.json
             10/ALSA/2026/ALSA-2026:9689.json
             10/ALSA/2026/ALSA-2026:9693.json
-          # Feed removals a human has accepted as genuine; the guard lets these
-          # deletions propagate instead of failing. Remove an entry once the
-          # file has left HEAD.
-          ACCEPTED_REMOVAL_PATHS: ""
         run: |
           set -euo pipefail
           dir="ghcr.io/${{ github.repository }}/vuls-data-raw-alma-errata"
@@ -361,23 +365,16 @@ jobs:
             snapshots+=("$line")
           done <<< "${RESTORE_SNAPSHOTS}"
 
-          declare -A restore accepted
+          declare -A restore
           while IFS= read -r line; do
             line="${line//[[:space:]]/}"
             [ -n "$line" ] || continue
             restore["$line"]=1
           done <<< "${RESTORE_PATHS}"
-          while IFS= read -r line; do
-            line="${line//[[:space:]]/}"
-            [ -n "$line" ] || continue
-            accepted["$line"]=1
-          done <<< "${ACCEPTED_REMOVAL_PATHS}"
 
-          # Unexpected drop: carried by the pre-fetch HEAD (this step runs
-          # before Commit), missing from the fresh fetch, in neither list.
-          # Fail fast - if this trips the run is dying regardless, so don't
-          # restore first.
-          unexpected=()
+          # Files the pre-fetch HEAD carries (this step runs before Commit)
+          # that the fresh fetch did not write and RESTORE_PATHS does not list.
+          dropped=()
           while IFS= read -r rel; do
             case "$rel" in
               *.json) ;;
@@ -385,12 +382,44 @@ jobs:
             esac
             [ ! -e "$dir/$rel" ] || continue
             [ -z "${restore[$rel]:-}" ] || continue
-            [ -z "${accepted[$rel]:-}" ] || continue
-            unexpected+=("$rel")
+            dropped+=("$rel")
           done < <(git -C "$dir" ls-tree -r --name-only HEAD)
+
+          # One HTML directory index GET per version involved; membership in
+          # the index is the still-published oracle. curl -f: an unreachable
+          # index fails the job (indeterminate is not "retired"); an index
+          # that parses to zero entries likewise.
+          declare -A html versions
+          for rel in "${dropped[@]:+"${dropped[@]}"}"; do versions["${rel%%/*}"]=1; done
+          for rel in "${!restore[@]}"; do [ -e "$dir/$rel" ] || versions["${rel%%/*}"]=1; done
+          for v in "${!versions[@]}"; do
+            n=0
+            while IFS= read -r f; do
+              html["$v/$f"]=1
+              n=$((n + 1))
+            done < <(curl -fsS --retry 3 --max-time 60 "${ERRATA_HTML_BASE}/$v/" | grep -oE 'href="AL[A-Z]+-[0-9]+-[0-9A-Za-z]+\.html"' | sed -E 's/^href="//; s/"$//' | sort -u)
+            if [ "$n" -eq 0 ]; then
+              echo "::error::alma-errata: parsed 0 advisory pages from ${ERRATA_HTML_BASE}/$v/ index; cannot arbitrate feed drops (page layout changed?)"
+              exit 1
+            fi
+            echo "index $v: $n advisory pages"
+          done
+
+          # Arbitrate the unlisted drops. Fail fast before restoring - if this
+          # trips the run is dying regardless.
+          unexpected=()
+          for rel in "${dropped[@]:+"${dropped[@]}"}"; do
+            v="${rel%%/*}"
+            base="$(basename "$rel" .json)"
+            if [ -n "${html[$v/${base//:/-}.html]:-}" ]; then
+              unexpected+=("$rel")
+            else
+              echo "::warning::alma-errata ${rel}: dropped from the feed and its HTML page is gone; propagating the upstream retirement."
+            fi
+          done
           if [ "${#unexpected[@]}" -gt 0 ]; then
-            printf '::error::alma-errata: %d advisory(ies) dropped from the feed but not in RESTORE_PATHS / ACCEPTED_REMOVAL_PATHS: %s\n' "${#unexpected[@]}" "${unexpected[*]}"
-            echo "If upstream re-curated again, add them to RESTORE_PATHS; if the removals are genuine, add them to ACCEPTED_REMOVAL_PATHS."
+            printf '::error::alma-errata: %d advisory(ies) dropped from the feed while their HTML pages are still published: %s\n' "${#unexpected[@]}" "${unexpected[*]}"
+            echo "Upstream re-curated the feed again; add them to RESTORE_PATHS (see https://bugs.almalinux.org/view.php?id=644)."
             exit 1
           fi
 
@@ -399,6 +428,12 @@ jobs:
             if [ -e "$dir/$rel" ]; then
               echo "::warning::alma-errata ${rel}: carried by the feed again; remove it from RESTORE_PATHS."
               continue
+            fi
+            v="${rel%%/*}"
+            base="$(basename "$rel" .json)"
+            if [ -z "${html[$v/${base//:/-}.html]:-}" ]; then
+              echo "::error::alma-errata ${rel}: in RESTORE_PATHS but upstream retired it (HTML page gone); remove the entry to accept the retirement."
+              exit 1
             fi
             src=""
             for snap in "${snapshots[@]}"; do

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -12,7 +12,6 @@ on:
         required: true
         type: choice
         options:
-          - alma-errata
           - alma-osv
           - alma-oval
           - alpine-osv


### PR DESCRIPTION
## Summary

- AlmaLinux has re-curated the AlmaLinux 10 `errata.full.json` feed twice, silently dropping published advisories while their HTML pages (https://errata.almalinux.org/10/) and the official OSV export (`AlmaLinux/osv-database`, osv.dev) keep carrying them:
  - `cb5d6bc44` (raw, 2025-11-26): **-102 advisories** (the ALSA-2025:7457..19772 range + ALSA-2025:A003/A006)
  - `e64c5ca88` (raw, 2026-05-27): **-143 advisories**, ~376 CVEs losing detection coverage — the event that forced the current alma-errata pin in `db-main.mk` / `db-nightly.mk`
  - Upstream inquiry about which source is authoritative: https://bugs.almalinux.org/view.php?id=644 (no response yet)
- Split the alma-errata fetch out of `fetch-main` into its own workflow following the `fetch-paloalto-json-or-csaf.yml` pattern: after the fetch rewrites the tree from the current feed, restore **exactly the 245 explicitly listed advisories**, each from the pinned pre-purge snapshot its list block declares (`RESTORE_SNAPSHOT_N` / `RESTORE_PATHS_N` pairs: 143 from `8255896a`, 102 from `593d3bca` — the parents of the two purge commits). Nothing unlisted is ever restored, per-file provenance is explicit in the diff, and a misassigned or duplicated entry fails the job.
- Every disappearance is arbitrated against the **upstream HTML directory index** (one GET per version; zero requests when nothing dropped; the Fetch step already depends on the same host):
  - unlisted drop whose HTML page is **still published** → feed re-curation → job fails; human appends to a `RESTORE_PATHS_N` block
  - unlisted drop whose HTML page is **gone** → genuine upstream retirement → deletion propagates with a `::warning::`
  - listed entry **about to be restored** whose HTML page is **gone** → job fails until the entry is removed (explicit acceptance), so a restore can never resurrect something upstream fully retired (entries the feed itself carries again are the feed's business, not the restore logic's — they just emit a prune-the-list warning)
  - unreachable / zero-entry index → job fails (indeterminate is never treated as retired)
- A gc/truncate guard hard-fails the job if a pinned snapshot ever vanishes from history; an entry the feed carries again emits a `::warning::` prompting list pruning.

## Verification

- `actionlint` clean on the new/changed workflows (the two pre-existing SC2086 infos in `fetch-all.yml`'s `check` job are untouched).
- Restore step simulated against the real `vuls-data-raw-alma-errata` dotgit and the live HTML index (511 pages parsed):
  - normal run: 0 unexpected drops, **245 files restored** (143 from `8255896a`, 102 from `593d3bca`); resulting AlmaLinux 10 set (511) **matches both the osv.dev export and the HTML index exactly**
  - unlisted drop with a live HTML page → fails listing the path
  - listed entry without an HTML page → fails demanding list removal
  - drop without an HTML page → warning + deletion propagates while the rest restore
  - entry declared under a snapshot that does not carry it → fails pointing at the misassignment
  - entry listed in more than one `RESTORE_PATHS_N` block → fails as a duplicate
- Snapshot layouts verified identical to the current fetcher layout (`<version>/ALSA/<year>/<ID>.json`), so restored files stay under fetch management.

## Follow-up (separate PR)

Once this has run and `extract alma-errata` has picked the restored advisories up, unpin alma-errata in `db-main.mk` / `db-nightly.mk`. The first unpinned run will trip diff-guard on alma_10/alma:10 by design (baseline jump) and needs the usual promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


