### PR TITLE
chore(db): unpin alma-errata extracted, restore branch tracking

### DIFF
--- a/db-main.mk
+++ b/db-main.mk
@@ -6,11 +6,7 @@ DBPATH := ~/.cache/vuls/vuls.db
 .PHONY: db-build
 db-build:
 	vuls db init --dbtype ${DBTYPE} --dbpath ${DBPATH}
-	# alma-errata: temporarily pinned to the last extracted commit that built a passing DB
-	# (extracted anchor of vuls-nightly-db@sha256:b97cdf2a — main :0/:latest at 2026-05-27).
-	# Upstream AlmaLinux 10 errata is mid-republish (large ALSA retirements); restore to
-	# ${BRANCH} once the new baseline settles.
-	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=564e8bdd1c936e2f09452a6370a0cd63c6b0be3d DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}

--- a/db-nightly.mk
+++ b/db-nightly.mk
@@ -6,11 +6,7 @@ DBPATH := ~/.cache/vuls/vuls.db
 .PHONY: db-build
 db-build:
 	vuls db init --dbtype ${DBTYPE} --dbpath ${DBPATH}
-	# alma-errata: temporarily pinned to the last extracted commit that built a passing DB
-	# (extracted anchor of vuls-nightly-db@sha256:06eb4252 — :nightly at 2026-05-27).
-	# Upstream AlmaLinux 10 errata is mid-republish (large ALSA retirements); restore to
-	# ${BRANCH} once the new baseline settles.
-	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=e6b3fdedd7b245088c5409500c015a3e316140c6 DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
## Summary

Reverts the temporary alma-errata pin from #160. The 2026-05-27 upstream re-curation that forced it is now handled structurally: #191 restores the feed-dropped advisories at fetch time, so the extracted data has regained everything upstream still publishes.

- `db-main.mk`: `BRANCH=564e8bdd...` → `BRANCH=${BRANCH}` (pin comment removed)
- `db-nightly.mk`: `BRANCH=e6b3fded...` → `BRANCH=${BRANCH}` (pin comment removed)

## Verification of the restored data (2026-07-07)

| source | AlmaLinux 10 advisories | vs osv.dev export |
|---|---|---|
| raw `4578455e6` (post-#191 fetch) | 514 | exact match |
| extracted **main** `a6a277e6a0` | 514 | exact match |
| extracted **nightly** `49587f6b88` | 514 | exact match |

The upstream HTML directory index also carries the same 514 pages. `make -n` dry-runs pass for both makefiles (db-nightly.yml overrides `BRANCH=nightly` at invocation as before).

## Expected first-run behavior (operator action required)

The current DB baselines were built with the pinned data (alma_10 detection baseline 259). The first unpinned **DB** and **DB(Nightly)** runs will trip diff-guard on `alma_10` / `alma:10` with a large one-time jump (259 → ~514 detections) — this is the intended baseline reset, not a regression. Promote the candidate digests to accept it:

```
gh workflow run promote-digest.yml --repo vulsio/vuls-data-db -f digest=sha256:<db-main candidate> -f tag=0
gh workflow run promote-digest.yml --repo vulsio/vuls-data-db -f digest=sha256:<db-nightly candidate> -f tag=nightly
```

Subsequent runs compare against the new baseline and should pass normal thresholds (the restored set is append-only going forward; #191's guard arbitrates any future upstream drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)