### PR TITLE
fix(ci/action-run-summary): render 2nd+ failed-job heading links

### DIFF
--- a/.github/workflows/action-run-summary.yml
+++ b/.github/workflows/action-run-summary.yml
@@ -162,6 +162,7 @@ jobs:
             # Reuse the precomputed log-page link (falls back to the run URL).
             job_url="${JOB_URL["$job_name"]:-$url}"
 
+            echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "---" >> "$GITHUB_STEP_SUMMARY"
             echo "#### [$(md_escape "$job_name")](${job_url})" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

In the failure-report step summary (e.g. [run 28900094824](https://github.com/vulsio/vuls-data-db/actions/runs/28900094824)), the first failed-job heading is a clickable link to the job's log page, but the second and later headings render as plain text.

## Cause

Each job section ends with a `</details>` line, and the next job's `---` + `#### [job](url)` heading was emitted immediately after it with no blank line. Per CommonMark, an HTML block started by `<details>` only ends at a blank line, so every heading after the first was swallowed into the preceding raw-HTML block and not parsed as Markdown.

## Fix

Emit a blank line before each job's separator/heading, terminating the previous HTML block. This also prevents `---` after a bare `(no log available)` paragraph from turning it into a setext heading.

Verified by re-running the summary script locally against run 28900094824: every `</details>` is now followed by a blank line before the next `---`/heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)