### PR TITLE
docs(claude/skills): add diff-guard-triage for failed DB run

### DIFF
--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -38,15 +38,16 @@ Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. Th
 - Tag promotions happen via two paths, and the baseline is the digest from whichever promotion completed most recently **before the failed run's diff-guard step executed** (a tag can be moved by another run while the failed run is in progress) — check both:
   - Automatic: a **successful** DB / DB(Nightly) run's own `Promote digest to :latest and :<schema_version>` (or `:nightly`) step. The failed run's own step is **skipped**, but an earlier successful run of the same workflow may have moved the tag this way. Find it and read the promoted digest from its "Pushed candidate image" summary / promote step log:
     ```sh
-    gh run list --repo vulsio/vuls-data-db --workflow <db-main.yml|db-nightly.yml> --status success --limit 5 --json createdAt,databaseId,displayTitle
+    gh run list --repo vulsio/vuls-data-db --workflow db-main.yml --status success --limit 5 --json createdAt,databaseId,displayTitle
     ```
+    (use `--workflow db-nightly.yml` when triaging a DB(Nightly) run)
   - Manual: the `DB(Promote Digest)` workflow (`.github/workflows/promote-digest.yml`), invoked via `workflow_dispatch`, with target tag matching the workflow (e.g., `:0` for db-main, `:nightly` for db-nightly):
     ```sh
     gh run list --repo vulsio/vuls-data-db --workflow promote-digest.yml --limit 20 --json createdAt,displayTitle,conclusion
     ```
     The `displayTitle` is `Promote :<tag> <- <digest> by @<actor>` (see `run-name` in `promote-digest.yml`).
 - The most recent of the two is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@<digest>`.
-- When in doubt, confirm against the registry itself: `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` — pick the most recent version whose `tags` contained the desired tag at the moment the failed run's diff-guard step executed.
+- Note the registry API (`gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions`) only reflects **current** tag→digest associations — use it to sanity-check the present state, not to reconstruct where a tag pointed in the past. Historical baselines must come from the Actions promotion history above.
 
 ## 3. Extract anchors from each DB
 

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: diff-guard-triage
+description: "Triage a failed DB workflow run on vulsio/vuls-data-db where the diff-guard step (vuls diff detection / vuls diff db) failed. Classify the cause as upstream-driven, extractor-driven, vuls2-builder-driven, or threshold-tuning, and cite a smoking-gun raw/extracted diff. Trigger when the user pastes a failed vuls-data-db DB run URL and asks why it failed or to investigate upstream/raw/extracted changes."
+---
+
+# Diff guard triage
+
+## 0. Prerequisites
+
+- `vuls` (vuls2), `vuls-data-update`, `gh`, `jq`, and `git` on PATH. Install the first two from the same refs CI uses:
+  ```sh
+  go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
+  go install github.com/MaineK00n/vuls2/cmd/vuls@main
+  ```
+- Local checkouts of vuls2 / vuls-data-update are **optional**. The steps that inspect their commit history rule out via the GitHub API first, and clone on demand only when a deep dive is needed.
+
+## 1. Identify which DB workflow fired
+
+The DB workflow exists in two flavors. The baseline tag differs:
+
+| Workflow file | Baseline tag | Notes |
+| --- | --- | --- |
+| `.github/workflows/db-main.yml` (workflow name: **DB**) | `ghcr.io/vulsio/vuls-nightly-db:<schema_version>` (computed at build time, currently `:0`) | Promoted to `:latest` and `:<schema_version>` on pass |
+| `.github/workflows/db-nightly.yml` (workflow name: **DB Nightly**) | `ghcr.io/vulsio/vuls-nightly-db:nightly` (literal) | Promoted to `:nightly` on pass |
+
+Read the failed run's workflow name from `gh run view --json workflowName` and pick the right baseline tag. The `schema_version` comes from a `Save vuls.db schema_version` step that runs `vuls db search metadata --dbpath ./vuls.db | jq .schema_version` — re-derive it from the run's logs if you need the exact value at the time.
+
+Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. The "nightly" in the repo name is a historical artifact — `db-main.yml` also publishes to it.
+
+## 2. Pin both anchors
+
+**Target** (the failed candidate, untagged):
+- Read the run summary's "Pushed candidate image" section, or scrape `digest=` from the `Push vuls.db to GHCR (tagless, digest-only)` step's log.
+- Form the ref: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
+- The image is intentionally untagged on failure — promotion to `:<schema_version>` / `:nightly` is gated on diff-guard passing.
+
+**Baseline** (what `:<tag>` was pointing to at the moment diff-guard ran):
+- Tag promotions happen via two paths:
+  - Automatic: the failed run's own `Promote digest to :latest and :<schema_version>` (or `:nightly`) step — **skipped if diff-guard fails**, so it doesn't affect the baseline you want.
+  - Manual: the `DB(Promote Digest)` workflow (`.github/workflows/promote-digest.yml`), invoked via `workflow_dispatch`.
+- Find the most recent successful `DB(Promote Digest)` run with target tag matching the workflow (e.g., `:0` for db-main, `:nightly` for db-nightly) that completed **before** the failed run started:
+  ```sh
+  gh run list --repo vulsio/vuls-data-db --workflow promote-digest.yml --limit 20 --json createdAt,displayTitle,conclusion
+  ```
+  The `displayTitle` is `Promote sha256:<digest> -> :<tag> by @<actor>`.
+- The matching digest is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
+
+If the target run pre-dates any manual promote run for that tag, fall back to inspecting `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` and pick the most recent version whose `tags` contained the desired tag at run time. This is rare; usually the promote-digest history is sufficient.
+
+## 3. Extract anchors from each DB
+
+```sh
+mkdir -p /tmp/db-investigation && cd /tmp/db-investigation
+vuls db fetch --dbpath ./baseline.db --repository <baseline ref> --no-progress
+vuls db fetch --dbpath ./target.db   --repository <target   ref> --no-progress
+
+# Builder version (vuls2). If different between b and t, builder is in scope.
+vuls db search metadata --dbpath ./baseline.db | jq '{schema_version, last_modified, created_by}'
+vuls db search metadata --dbpath ./target.db   | jq '{schema_version, last_modified, created_by}'
+
+# Per-source raw and extracted commits.
+vuls db search datasources --dbpath ./baseline.db | jq '.[] | select(.id=="<source>")'
+vuls db search datasources --dbpath ./target.db   | jq '.[] | select(.id=="<source>")'
+```
+
+The `<source>` is the datasource id from `db-main.mk` / `db-nightly.mk` — e.g. `ubuntu-cve-tracker`, `redhat-vex`, `debian-security-tracker-salsa`.
+
+For ubuntu specifically, only one source is enabled (`ubuntu-cve-tracker`). For other OS families, multiple sources may need to be checked.
+
+## 4. Diff in the right order (rule out builder → extractor → upstream)
+
+### a. vuls2 builder
+
+Compare `created_by` strings. If identical, builder is ruled out. If they differ, list vuls2's commits in the date range between the two strings' embedded timestamps before drawing conclusions:
+
+```sh
+gh api "repos/MaineK00n/vuls2/commits?since=<baseline_ts>&until=<target_ts>" \
+  --jq '.[] | .sha[0:7] + " " + .commit.committer.date + " " + (.commit.message | split("\n")[0])'
+```
+
+### b. vuls-data-update extractor
+
+The extractor binary that produced the extracted dotgit isn't recorded in the DB metadata. Approximate: look for commits touching `pkg/extract/<source>/` and `pkg/fetch/<source>/`, scoped to the date range between the two extracted commits' timestamps (from step 3).
+
+**Rule-out first** — no checkout needed:
+
+```sh
+for p in pkg/extract/<source> pkg/fetch/<source>; do
+  gh api "repos/MaineK00n/vuls-data-update/commits?path=$p&since=<baseline_ext_date>&until=<target_ext_date>" \
+    --jq '.[] | .sha[0:7] + " " + .commit.committer.date + " " + (.commit.message | split("\n")[0])'
+done
+```
+
+No commits → extractor is ruled out; move on to c. Commits found → they are candidates, and need a deep dive: the commits API truncates large patches and can't grep the tree, so use a real checkout. Prefer an existing local clone if the user has one; otherwise blobless-clone on demand:
+
+```sh
+[ -d /tmp/db-investigation/vuls-data-update ] || \
+  git clone --filter=blob:none https://github.com/MaineK00n/vuls-data-update /tmp/db-investigation/vuls-data-update
+git -C /tmp/db-investigation/vuls-data-update log -p \
+  --since=<baseline_ext_date> --until=<target_ext_date> -- pkg/extract/<source> pkg/fetch/<source>
+```
+
+Read each candidate commit's diff and the surrounding extraction logic (the current `pkg/extract/<source>/` tree) before drawing conclusions — a commit touching the path is a candidate, not a verdict.
+
+### c. extracted dotgit
+
+```sh
+vuls-data-update dotgit pull --dir /tmp/ex --restore ghcr.io/vulsio/vuls-data-db:vuls-data-extracted-<source>
+EX=/tmp/ex/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-<source>
+git -C "$EX" log --format='%h %ci' <baseline_ext>..<target_ext>
+git -C "$EX" diff --shortstat <baseline_ext>..<target_ext>
+```
+
+The range may span multiple commits. If it does, examine **each step**, not just the cumulative diff — different commits often represent different upstream activities (schema expansion vs. bulk triage, etc.).
+
+### d. raw dotgit
+
+```sh
+vuls-data-update dotgit pull --dir /tmp/raw --restore ghcr.io/vulsio/vuls-data-db:vuls-data-raw-<source>
+RAW=/tmp/raw/ghcr.io/vulsio/vuls-data-db/vuls-data-raw-<source>
+git -C "$RAW" log --format='%h %ci' <baseline_raw>..<target_raw>
+git -C "$RAW" diff --shortstat <baseline_raw>..<target_raw>
+```
+
+If raw also changed → upstream is the source of truth. If raw is unchanged but extracted moved → extractor is the source.
+
+## 5. Classify and cite
+
+Output the verdict as one of:
+
+- **upstream-driven** — raw moved, extractor unchanged, builder unchanged. Show the smoking-gun raw status flip (e.g., `needs-triage → needed`) on a representative file. Usually legitimate; consider per-target threshold override (see below).
+- **extractor-driven** — raw unchanged but extracted moved. Show a same-file diff between `<baseline_ext>` and `<target_ext>` and link to the offending commit in `pkg/extract/<source>/`.
+- **vuls2-builder-driven** — anchors unchanged but `created_by` differs. Link to the vuls2 commit in the date range.
+- **threshold-only** — small baseline (e.g. `ubuntu_2604` with baseline ~200 detections) tripping the global threshold on routine noise. Recommend a per-file or per-ecosystem override:
+  - Detection: `detection_change_rate_threshold_overrides` in the workflow's `with:` block (entries like `ubuntu_2604=20`).
+  - DB: `db_change_rate_threshold_overrides` (entries like `ubuntu:26.04=15`).
+
+Always cite at least one concrete CVE file diff (raw or extracted) as evidence — never just summarize "looks upstream".
+
+**Write the final triage report to the user in Japanese** (日本語), regardless of the language used during investigation. Keep identifiers verbatim — commit hashes, digests, CVE IDs, tags, file paths, workflow/source names, and metric tables stay as-is; only the prose (verdict, reasoning, recommendations) is in Japanese.
+
+## 6. Don't do this
+
+- **Don't** diff `HEAD vs HEAD~1` of the dotgit and call it the answer. The two anchors may span multiple commits, and you'll miss the earlier ones.
+- **Don't** treat `:0` / `:latest` / `:nightly` at *now* as the baseline. The baseline is what those tags pointed to **when the failed run executed**. Use the promote-digest history.
+- **Don't** assume `KB Change Rate = 0%` means "nothing changed". The metric measures one specific aspect of the bolt buckets and can show 0% even when many CVE entries had their `Vulnerable` flag flipped. Cross-check with raw status histograms (`grep -E '"status":' | sort | uniq -c`).
+- **Don't** auto-commit conclusions to memory. Each diff-guard failure has its own root cause; the procedure here is what should be remembered, not the verdict.

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -42,7 +42,7 @@ Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. Th
   ```sh
   gh run list --repo vulsio/vuls-data-db --workflow promote-digest.yml --limit 20 --json createdAt,displayTitle,conclusion
   ```
-  The `displayTitle` is `Promote sha256:<digest> -> :<tag> by @<actor>`.
+  The `displayTitle` is `Promote :<tag> <- sha256:<digest> by @<actor>` (see `run-name` in `promote-digest.yml`).
 - The matching digest is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
 
 If the target run pre-dates any manual promote run for that tag, fall back to inspecting `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` and pick the most recent version whose `tags` contained the desired tag at run time. This is rare; usually the promote-digest history is sufficient.
@@ -105,18 +105,20 @@ Read each candidate commit's diff and the surrounding extraction logic (the curr
 ### c. extracted dotgit
 
 ```sh
-vuls-data-update dotgit pull --dir /tmp/ex --restore ghcr.io/vulsio/vuls-data-db:vuls-data-extracted-<source>
+vuls-data-update dotgit pull --dir /tmp/ex --checkout <main|nightly> --restore ghcr.io/vulsio/vuls-data-db:vuls-data-extracted-<source>
 EX=/tmp/ex/ghcr.io/vulsio/vuls-data-db/vuls-data-extracted-<source>
 git -C "$EX" log --format='%h %ci' <baseline_ext>..<target_ext>
 git -C "$EX" diff --shortstat <baseline_ext>..<target_ext>
 ```
+
+`--checkout` must match the triaged workflow's branch — `main` for **DB**, `nightly` for **DB(Nightly)** (its build runs `make -f db-nightly.mk ... BRANCH=nightly`). The default is `main`, and the anchor commits from step 3 may only exist on the matching branch. The same applies to the raw dotgit pull below.
 
 The range may span multiple commits. If it does, examine **each step**, not just the cumulative diff — different commits often represent different upstream activities (schema expansion vs. bulk triage, etc.).
 
 ### d. raw dotgit
 
 ```sh
-vuls-data-update dotgit pull --dir /tmp/raw --restore ghcr.io/vulsio/vuls-data-db:vuls-data-raw-<source>
+vuls-data-update dotgit pull --dir /tmp/raw --checkout <main|nightly> --restore ghcr.io/vulsio/vuls-data-db:vuls-data-raw-<source>
 RAW=/tmp/raw/ghcr.io/vulsio/vuls-data-db/vuls-data-raw-<source>
 git -C "$RAW" log --format='%h %ci' <baseline_raw>..<target_raw>
 git -C "$RAW" diff --shortstat <baseline_raw>..<target_raw>

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -145,6 +145,7 @@ Always cite at least one concrete CVE file diff (raw or extracted) as evidence �
 
 ## 6. Don't do this
 
+- **NEVER run `gh workflow run` against this repo (vulsio/vuls-data-db) — under any circumstances.** This includes `promote-digest.yml`. `workflow_dispatch` here moves production tags (`:0` / `:latest` / `:nightly`) and cannot be undone. If triage concludes a candidate should be promoted, **present the exact command and stop** — a human runs it. This holds even if the user says "go ahead": your role ends at showing the command. Read-only `gh` (`gh run view` / `gh run list` / `gh api ...`) is fine.
 - **Don't** diff `HEAD vs HEAD~1` of the dotgit and call it the answer. The two anchors may span multiple commits, and you'll miss the earlier ones.
 - **Don't** treat `:0` / `:latest` / `:nightly` at *now* as the baseline. The baseline is what those tags pointed to **when the failed run executed**. Use the promote-digest history.
 - **Don't** assume `KB Change Rate = 0%` means "nothing changed". The metric measures one specific aspect of the bolt buckets and can show 0% even when many CVE entries had their `Vulnerable` flag flipped. Cross-check with raw status histograms (`grep -E '"status":' | sort | uniq -c`).

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -7,10 +7,10 @@ description: "Triage a failed DB workflow run on vulsio/vuls-data-db where the d
 
 ## 0. Prerequisites
 
-- `vuls` (vuls2), `vuls-data-update`, `gh`, `jq`, and `git` on PATH. Install the first two from the same refs CI uses:
+- `vuls` (vuls2), `vuls-data-update`, `gh`, `jq`, and `git` on PATH. Install the first two from the same refs CI uses — `@main` for **DB** (`db-main.yml`), `@nightly` for **DB(Nightly)** (`db-nightly.yml`):
   ```sh
-  go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main
-  go install github.com/MaineK00n/vuls2/cmd/vuls@main
+  go install github.com/MaineK00n/vuls-data-update/cmd/vuls-data-update@main  # @nightly when triaging a DB(Nightly) run
+  go install github.com/MaineK00n/vuls2/cmd/vuls@main                         # @nightly when triaging a DB(Nightly) run
   ```
 - Local checkouts of vuls2 / vuls-data-update are **optional**. The steps that inspect their commit history rule out via the GitHub API first, and clone on demand only when a deep dive is needed.
 
@@ -21,7 +21,7 @@ The DB workflow exists in two flavors. The baseline tag differs:
 | Workflow file | Baseline tag | Notes |
 | --- | --- | --- |
 | `.github/workflows/db-main.yml` (workflow name: **DB**) | `ghcr.io/vulsio/vuls-nightly-db:<schema_version>` (computed at build time, currently `:0`) | Promoted to `:latest` and `:<schema_version>` on pass |
-| `.github/workflows/db-nightly.yml` (workflow name: **DB Nightly**) | `ghcr.io/vulsio/vuls-nightly-db:nightly` (literal) | Promoted to `:nightly` on pass |
+| `.github/workflows/db-nightly.yml` (workflow name: **DB(Nightly)**) | `ghcr.io/vulsio/vuls-nightly-db:nightly` (literal) | Promoted to `:nightly` on pass |
 
 Read the failed run's workflow name from `gh run view --json workflowName` and pick the right baseline tag. The `schema_version` comes from a `Save vuls.db schema_version` step that runs `vuls db search metadata --dbpath ./vuls.db | jq .schema_version` — re-derive it from the run's logs if you need the exact value at the time.
 

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -35,17 +35,18 @@ Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. Th
 - The image is intentionally untagged on failure — promotion to `:<schema_version>` / `:nightly` is gated on diff-guard passing.
 
 **Baseline** (what `:<tag>` was pointing to at the moment diff-guard ran):
-- Tag promotions happen via two paths:
-  - Automatic: the failed run's own `Promote digest to :latest and :<schema_version>` (or `:nightly`) step — **skipped if diff-guard fails**, so it doesn't affect the baseline you want.
-  - Manual: the `DB(Promote Digest)` workflow (`.github/workflows/promote-digest.yml`), invoked via `workflow_dispatch`.
-- Find the most recent successful `DB(Promote Digest)` run with target tag matching the workflow (e.g., `:0` for db-main, `:nightly` for db-nightly) that completed **before** the failed run started:
-  ```sh
-  gh run list --repo vulsio/vuls-data-db --workflow promote-digest.yml --limit 20 --json createdAt,displayTitle,conclusion
-  ```
-  The `displayTitle` is `Promote :<tag> <- sha256:<digest> by @<actor>` (see `run-name` in `promote-digest.yml`).
-- The matching digest is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
-
-If the target run pre-dates any manual promote run for that tag, fall back to inspecting `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` and pick the most recent version whose `tags` contained the desired tag at run time. This is rare; usually the promote-digest history is sufficient.
+- Tag promotions happen via two paths, and the baseline is the digest from whichever promotion completed most recently **before** the failed run started — check both:
+  - Automatic: a **successful** DB / DB(Nightly) run's own `Promote digest to :latest and :<schema_version>` (or `:nightly`) step. The failed run's own step is **skipped**, but an earlier successful run of the same workflow may have moved the tag this way. Find it and read the promoted digest from its "Pushed candidate image" summary / promote step log:
+    ```sh
+    gh run list --repo vulsio/vuls-data-db --workflow <db-main.yml|db-nightly.yml> --status success --limit 5 --json createdAt,databaseId,displayTitle
+    ```
+  - Manual: the `DB(Promote Digest)` workflow (`.github/workflows/promote-digest.yml`), invoked via `workflow_dispatch`, with target tag matching the workflow (e.g., `:0` for db-main, `:nightly` for db-nightly):
+    ```sh
+    gh run list --repo vulsio/vuls-data-db --workflow promote-digest.yml --limit 20 --json createdAt,displayTitle,conclusion
+    ```
+    The `displayTitle` is `Promote :<tag> <- sha256:<digest> by @<actor>` (see `run-name` in `promote-digest.yml`).
+- The most recent of the two is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
+- When in doubt, confirm against the registry itself: `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` — pick the most recent version whose `tags` contained the desired tag at the failed run's start time.
 
 ## 3. Extract anchors from each DB
 
@@ -74,7 +75,7 @@ For ubuntu specifically, only one source is enabled (`ubuntu-cve-tracker`). For 
 Compare `created_by` strings. If identical, builder is ruled out. If they differ, list vuls2's commits in the date range between the two strings' embedded timestamps before drawing conclusions:
 
 ```sh
-gh api "repos/MaineK00n/vuls2/commits?since=<baseline_ts>&until=<target_ts>" \
+gh api --paginate "repos/MaineK00n/vuls2/commits?per_page=100&since=<baseline_ts>&until=<target_ts>" \
   --jq '.[] | .sha[0:7] + " " + .commit.committer.date + " " + (.commit.message | split("\n")[0])'
 ```
 
@@ -86,7 +87,7 @@ The extractor binary that produced the extracted dotgit isn't recorded in the DB
 
 ```sh
 for p in pkg/extract/<source> pkg/fetch/<source>; do
-  gh api "repos/MaineK00n/vuls-data-update/commits?path=$p&since=<baseline_ext_date>&until=<target_ext_date>" \
+  gh api --paginate "repos/MaineK00n/vuls-data-update/commits?per_page=100&path=$p&since=<baseline_ext_date>&until=<target_ext_date>" \
     --jq '.[] | .sha[0:7] + " " + .commit.committer.date + " " + (.commit.message | split("\n")[0])'
 done
 ```

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diff-guard-triage
-description: "Triage a failed DB workflow run on vulsio/vuls-data-db where the diff-guard step (vuls diff detection / vuls diff db) failed. Classify the cause as upstream-driven, extractor-driven, vuls2-builder-driven, or threshold-tuning, and cite a smoking-gun raw/extracted diff. Trigger when the user pastes a failed vuls-data-db DB run URL and asks why it failed or to investigate upstream/raw/extracted changes."
+description: "Triage a failed DB workflow run on vulsio/vuls-data-db where the diff-guard step (vuls diff detection / vuls diff db) failed. Classify the cause as upstream-driven, extractor-driven, vuls2-builder-driven, or threshold-only, and cite a smoking-gun raw/extracted diff. Trigger when the user pastes a failed vuls-data-db DB run URL and asks why it failed or to investigate upstream/raw/extracted changes."
 ---
 
 # Diff guard triage
@@ -20,10 +20,10 @@ The DB workflow exists in two flavors. The baseline tag differs:
 
 | Workflow file | Baseline tag | Notes |
 | --- | --- | --- |
-| `.github/workflows/db-main.yml` (workflow name: **DB**) | `ghcr.io/vulsio/vuls-nightly-db:<schema_version>` (computed at build time, currently `:0`) | Promoted to `:latest` and `:<schema_version>` on pass |
+| `.github/workflows/db-main.yml` (workflow name: **DB**) | `ghcr.io/vulsio/vuls-nightly-db:<schema_version>` (computed at build time, e.g. `:0`) | Promoted to `:latest` and `:<schema_version>` on pass |
 | `.github/workflows/db-nightly.yml` (workflow name: **DB(Nightly)**) | `ghcr.io/vulsio/vuls-nightly-db:nightly` (literal) | Promoted to `:nightly` on pass |
 
-Read the failed run's workflow name from `gh run view --json workflowName` and pick the right baseline tag. The `schema_version` comes from a `Save vuls.db schema_version` step that runs `vuls db search metadata --dbpath ./vuls.db | jq .schema_version` — re-derive it from the run's logs if you need the exact value at the time.
+Read the failed run's workflow name from `gh run view <run-id> --repo vulsio/vuls-data-db --json workflowName` and pick the right baseline tag. The `schema_version` comes from a `Save vuls.db schema_version` step that runs `vuls db search metadata --dbpath ./vuls.db | jq .schema_version` — re-derive it from the run's logs if you need the exact value at the time.
 
 Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. The "nightly" in the repo name is a historical artifact — `db-main.yml` also publishes to it.
 

--- a/.claude/skills/diff-guard-triage/SKILL.md
+++ b/.claude/skills/diff-guard-triage/SKILL.md
@@ -30,12 +30,12 @@ Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. Th
 ## 2. Pin both anchors
 
 **Target** (the failed candidate, untagged):
-- Read the run summary's "Pushed candidate image" section, or scrape `digest=` from the `Push vuls.db to GHCR (tagless, digest-only)` step's log.
-- Form the ref: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
+- Read the run summary's "Pushed candidate image" section, or scrape `digest=` from the `Push vuls.db to GHCR (tagless, digest-only)` step's log. `<digest>` below always means the full `sha256:<64hex>` string exactly as it appears there.
+- Form the ref: `ghcr.io/vulsio/vuls-nightly-db@<digest>`.
 - The image is intentionally untagged on failure — promotion to `:<schema_version>` / `:nightly` is gated on diff-guard passing.
 
 **Baseline** (what `:<tag>` was pointing to at the moment diff-guard ran):
-- Tag promotions happen via two paths, and the baseline is the digest from whichever promotion completed most recently **before** the failed run started — check both:
+- Tag promotions happen via two paths, and the baseline is the digest from whichever promotion completed most recently **before the failed run's diff-guard step executed** (a tag can be moved by another run while the failed run is in progress) — check both:
   - Automatic: a **successful** DB / DB(Nightly) run's own `Promote digest to :latest and :<schema_version>` (or `:nightly`) step. The failed run's own step is **skipped**, but an earlier successful run of the same workflow may have moved the tag this way. Find it and read the promoted digest from its "Pushed candidate image" summary / promote step log:
     ```sh
     gh run list --repo vulsio/vuls-data-db --workflow <db-main.yml|db-nightly.yml> --status success --limit 5 --json createdAt,databaseId,displayTitle
@@ -44,9 +44,9 @@ Both workflows use the same OCI repository: `ghcr.io/vulsio/vuls-nightly-db`. Th
     ```sh
     gh run list --repo vulsio/vuls-data-db --workflow promote-digest.yml --limit 20 --json createdAt,displayTitle,conclusion
     ```
-    The `displayTitle` is `Promote :<tag> <- sha256:<digest> by @<actor>` (see `run-name` in `promote-digest.yml`).
-- The most recent of the two is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@sha256:<digest>`.
-- When in doubt, confirm against the registry itself: `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` — pick the most recent version whose `tags` contained the desired tag at the failed run's start time.
+    The `displayTitle` is `Promote :<tag> <- <digest> by @<actor>` (see `run-name` in `promote-digest.yml`).
+- The most recent of the two is the baseline. Form the ref the same way: `ghcr.io/vulsio/vuls-nightly-db@<digest>`.
+- When in doubt, confirm against the registry itself: `gh api /orgs/vulsio/packages/container/vuls-nightly-db/versions` — pick the most recent version whose `tags` contained the desired tag at the moment the failed run's diff-guard step executed.
 
 ## 3. Extract anchors from each DB
 
@@ -131,7 +131,7 @@ If raw also changed → upstream is the source of truth. If raw is unchanged but
 
 Output the verdict as one of:
 
-- **upstream-driven** — raw moved, extractor unchanged, builder unchanged. Show the smoking-gun raw status flip (e.g., `needs-triage → needed`) on a representative file. Usually legitimate; consider per-target threshold override (see below).
+- **upstream-driven** — raw moved, no vuls-data-update extractor/fetch code changes in the window (step 4b), builder unchanged. Show the smoking-gun raw status flip (e.g., `needs-triage → needed`) on a representative file. Usually legitimate; consider per-target threshold override (see below).
 - **extractor-driven** — raw unchanged but extracted moved. Show a same-file diff between `<baseline_ext>` and `<target_ext>` and link to the offending commit in `pkg/extract/<source>/`.
 - **vuls2-builder-driven** — anchors unchanged but `created_by` differs. Link to the vuls2 commit in the date range.
 - **threshold-only** — small baseline (e.g. `ubuntu_2604` with baseline ~200 detections) tripping the global threshold on routine noise. Recommend a per-file or per-ecosystem override:


### PR DESCRIPTION
## Summary

Adds a Claude Code skill (`.claude/skills/diff-guard-triage/SKILL.md`) that triages failed DB workflow runs where the diff-guard step (`vuls diff detection` / `vuls diff db`) failed. Anyone cloning this repo gets the skill automatically as a project skill.

The procedure classifies the cause as **upstream-driven** / **extractor-driven** / **vuls2-builder-driven** / **threshold-only**, always citing a smoking-gun raw/extracted diff, and covers pinning the correct baseline via the promote-digest history (not the current tag positions).

Migrated from a personal `~/.claude/skills` copy, with one rework so a lone vuls-data-db checkout plus the CLI binaries is enough to run a triage: the vuls2 / vuls-data-update commit-history checks first rule out via the GitHub commits API, and blobless-clone on demand only when a deep dive into extractor changes is needed.

## Test plan

- Verified the skill loads as a project skill in a Claude Code session (including nested discovery from a multi-repo parent workspace).
- Procedure content is unchanged from the personal copy that has been used for past diff-guard triages, apart from the API-first history checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)