### PR TITLE
chore(ci): add input-based run-name to dispatchable workflows

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,5 +1,7 @@
 name: Archive
 
+run-name: "Archive ${{ inputs.tag }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,5 +1,7 @@
 name: Backup
 
+run-name: "Backup ${{ inputs.src-repository }}:${{ inputs.tag }} -> ${{ inputs.dest-repository }}:${{ inputs.tag }}-${{ inputs.tag-suffix }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/check-layer-size.yml
+++ b/.github/workflows/check-layer-size.yml
@@ -1,5 +1,7 @@
 name: Check if layer size exceeds threshold
 
+run-name: "Check Layer Size ${{ inputs.repository }}:${{ inputs.tag }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,5 +1,7 @@
 name: Cleanup
 
+run-name: "Cleanup untagged images in ${{ inputs.package }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-eol.yml
+++ b/.github/workflows/extract-eol.yml
@@ -1,5 +1,7 @@
 name: Extract EOL
 
+run-name: "Extract vuls-data-extracted-eol@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -1,5 +1,7 @@
 name: Extract Main
 
+run-name: "Extract vuls-data-extracted-${{ inputs.target }}@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-nvd-cve.yml
+++ b/.github/workflows/extract-nvd-cve.yml
@@ -1,5 +1,7 @@
 name: Extract NVD CVE (API, Feed v2)
 
+run-name: "Extract vuls-data-extracted-${{ inputs.target }}@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
+++ b/.github/workflows/extract-redhat-rhel-csaf-or-vex.yml
@@ -1,5 +1,7 @@
 name: Extract RedHat RHEL Only (CSAF, VEX)
 
+run-name: "Extract vuls-data-extracted-${{ inputs.target }}-rhel@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-redhat-rhel-oval-v1.yml
+++ b/.github/workflows/extract-redhat-rhel-oval-v1.yml
@@ -1,5 +1,7 @@
 name: Extract RedHat RHEL Only (OVALv1)
 
+run-name: "Extract vuls-data-extracted-redhat-oval-v1-rhel@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-redhat-rhel-oval-v2.yml
+++ b/.github/workflows/extract-redhat-rhel-oval-v2.yml
@@ -1,5 +1,7 @@
 name: Extract RedHat RHEL Only (OVALv2)
 
+run-name: "Extract vuls-data-extracted-redhat-oval-v2-rhel@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/extract-redhat.yml
+++ b/.github/workflows/extract-redhat.yml
@@ -1,5 +1,7 @@
 name: Extract RedHat
 
+run-name: "Extract vuls-data-extracted-${{ inputs.target }}@${{ inputs.branch }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fetch-alma-errata.yml
+++ b/.github/workflows/fetch-alma-errata.yml
@@ -1,5 +1,7 @@
 name: Fetch Alma (Errata)
 
+run-name: "Fetch vuls-data-raw-alma-errata by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
+++ b/.github/workflows/fetch-cisco-cvrf-or-csaf.yml
@@ -1,5 +1,7 @@
 name: Fetch Cisco (CVRF, CSAF)
 
+run-name: "Fetch vuls-data-raw-${{ inputs.target }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fetch-cisco-json.yml
+++ b/.github/workflows/fetch-cisco-json.yml
@@ -1,5 +1,7 @@
 name: Fetch Cisco JSON
 
+run-name: "Fetch vuls-data-raw-cisco-json by @${{ github.actor }}"
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/fetch-enisa-euvd-list.yml
+++ b/.github/workflows/fetch-enisa-euvd-list.yml
@@ -1,5 +1,7 @@
 name: Fetch EUVD List
 
+run-name: "Fetch vuls-data-raw-enisa-euvd-list${{ inputs.fetch_single && ' (single)' || '' }} by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-epss.yml
+++ b/.github/workflows/fetch-epss.yml
@@ -1,5 +1,7 @@
 name: Fetch EPSS
 
+run-name: "Fetch vuls-data-raw-epss by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-fedora-api.yml
+++ b/.github/workflows/fetch-fedora-api.yml
@@ -1,5 +1,7 @@
 name: Fetch Fedora
 
+run-name: "Fetch vuls-data-raw-fedora-api by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-fortinet-csaf.yml
+++ b/.github/workflows/fetch-fortinet-csaf.yml
@@ -1,5 +1,7 @@
 name: Fetch Fortinet CSAF
 
+run-name: "Fetch vuls-data-raw-fortinet-csaf${{ inputs.fetch_all && ' (all)' || '' }} by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-fortinet-cvrf.yml
+++ b/.github/workflows/fetch-fortinet-cvrf.yml
@@ -1,5 +1,7 @@
 name: Fetch Fortinet CVRF
 
+run-name: "Fetch vuls-data-raw-fortinet-cvrf${{ inputs.fetch_all && ' (all)' || '' }} by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-main.yml
+++ b/.github/workflows/fetch-main.yml
@@ -1,5 +1,7 @@
 name: Fetch Main
 
+run-name: "Fetch vuls-data-raw-${{ inputs.target }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fetch-msuc.yml
+++ b/.github/workflows/fetch-msuc.yml
@@ -1,5 +1,7 @@
 name: Fetch MSUC
 
+run-name: "Fetch vuls-data-raw-microsoft-msuc by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-nuclei-api.yml
+++ b/.github/workflows/fetch-nuclei-api.yml
@@ -1,5 +1,7 @@
 name: Fetch Nuclei API
 
+run-name: "Fetch vuls-data-raw-nuclei-api by @${{ github.actor }}"
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/fetch-nvd-api.yml
+++ b/.github/workflows/fetch-nvd-api.yml
@@ -1,5 +1,7 @@
 name: Fetch NVD API
 
+run-name: "Fetch vuls-data-raw-${{ inputs.target }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fetch-paloalto-json-or-csaf.yml
+++ b/.github/workflows/fetch-paloalto-json-or-csaf.yml
@@ -1,5 +1,7 @@
 name: Fetch Palo Alto (JSON, CSAF)
 
+run-name: "Fetch vuls-data-raw-${{ inputs.target }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fetch-redhat-package-manifest.yml
+++ b/.github/workflows/fetch-redhat-package-manifest.yml
@@ -1,5 +1,7 @@
 name: Fetch RedHat Package Manifest
 
+run-name: "Fetch vuls-data-raw-redhat-package-manifest by @${{ github.actor }}"
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/fetch-variot.yml
+++ b/.github/workflows/fetch-variot.yml
@@ -1,5 +1,7 @@
 name: Fetch VARIoT
 
+run-name: "Fetch vuls-data-raw-${{ inputs.target }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fetch-vulncheck.yml
+++ b/.github/workflows/fetch-vulncheck.yml
@@ -1,5 +1,7 @@
 name: Fetch VulnCheck
 
+run-name: "Fetch vuls-data-raw-${{ inputs.target }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -1,5 +1,7 @@
 name: Git GC
 
+run-name: "Git GC ${{ inputs.repository }}:${{ inputs.tag }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/restore-all.yml
+++ b/.github/workflows/restore-all.yml
@@ -1,5 +1,7 @@
 name: Restore All
 
+run-name: "Restore All (${{ inputs.tag-suffix }}) by @${{ github.actor }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/restore.yml
+++ b/.github/workflows/restore.yml
@@ -1,5 +1,7 @@
 name: Restore
 
+run-name: "Restore ${{ inputs.repository }}:${{ inputs.tag }}-${{ inputs.tag-suffix }} -> ${{ github.repository }}:${{ inputs.tag }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/truncate.yml
+++ b/.github/workflows/truncate.yml
@@ -1,5 +1,7 @@
 name: Truncate
 
+run-name: "Truncate ${{ inputs.tag }} by @${{ github.actor }}"
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

Mirror the `promote-digest.yml` / `initialize.yml` pattern: interpolate the dispatch inputs (and actor) into `run-name`, so the Actions run list shows what each manual run targets instead of just the workflow name.

Example titles:

- `Extract vuls-data-extracted-<target>@<branch> by @actor` (extract-main and friends)
- `Fetch vuls-data-raw-<target> by @actor` (fetch-main and per-source fetch workflows)
- `Git GC <repository>:<tag> by @actor` (gc)
- `Backup <src>:<tag> -> <dest>:<tag>-<suffix> by @actor` (backup)

### Covered (31 workflows)

**Maintenance / extract family (16, first commit):** archive, backup, check-layer-size, cleanup, extract-eol, extract-main, extract-nvd-cve, extract-redhat, extract-redhat-rhel-csaf-or-vex, extract-redhat-rhel-oval-v1/v2, fetch-main, gc, restore, restore-all, truncate.

**Per-source fetch family (15, follow-up commit, per review):**
- with `inputs.target`, same shape as fetch-main: fetch-nvd-api, fetch-cisco-cvrf-or-csaf, fetch-paloalto-json-or-csaf, fetch-variot, fetch-vulncheck
- fixed target (literal raw-source name): fetch-alma-errata, fetch-cisco-json, fetch-enisa-euvd-list, fetch-epss, fetch-fedora-api, fetch-fortinet-csaf, fetch-fortinet-cvrf, fetch-msuc, fetch-nuclei-api, fetch-redhat-package-manifest
- boolean-flag dispatches surface the flag initialize.yml-style: fetch-enisa-euvd-list adds ` (single)` for `fetch_single`; fetch-fortinet-csaf/cvrf add ` (all)` for `fetch_all`

### Left as is

Workflows that also run on `schedule` / `workflow_run` (db-main, db-nightly, fetch-all, extract-all, backups, cleanups, ...) — `inputs` is empty on those paths so the title would degrade. `workflow_call`-only invocations render under the caller's run, so `run-name` never applies there.

## Verification

`actionlint .github/workflows/*.yml`: 60 findings before and after each commit — all pre-existing shellcheck style notes in `run:` scripts, zero new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)