### PR TITLE
feat(diff-guard): wire up per-source thresholds and CPE fixtures

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -66,31 +66,35 @@ inputs:
     description: OCI reference (repo:tag) to fetch the baseline vuls.db from.
     required: true
   db_change_rate_threshold:
-    description: "`vuls diff db` default change rate (%) threshold per ecosystem."
+    description: "`vuls diff db` default change rate (%) threshold per (ecosystem, data source)."
     required: true
   db_change_rate_threshold_overrides:
     description: |
-      Per-ecosystem overrides of the `vuls diff db` change rate threshold.
-      One "<ecosystem>=<rate>" entry per line (e.g. "ubuntu:26.04=25");
-      blank/whitespace-only lines are dropped. Empty value means "no
-      overrides" — every ecosystem uses db_change_rate_threshold.
+      Overrides of the `vuls diff db` change rate threshold. One entry per
+      line, either "<ecosystem>=<rate>" (e.g. "ubuntu:26.04=25", applies to
+      every data source in that ecosystem) or "<ecosystem>/<source>=<rate>"
+      (e.g. "cpe/cisco-json=30", single source, wins over the ecosystem key).
+      Blank/whitespace-only lines are dropped. Empty value means "no
+      overrides" — every (ecosystem, source) uses db_change_rate_threshold.
     required: false
     default: ""
   detection_change_rate_threshold:
-    description: "`vuls diff detection` default change rate (%) threshold per scan result."
+    description: "`vuls diff detection` default change rate (%) threshold per (scan result, data source)."
     required: true
   detection_change_rate_threshold_overrides:
     description: |
-      Per-file overrides of the `vuls diff detection` change rate threshold.
-      One "<file-basename>=<rate>" entry per line (e.g. "debian_13=8") where
-      the basename is the scan-result file name without ".json".
-      Blank/whitespace-only lines are dropped.
+      Overrides of the `vuls diff detection` change rate threshold. One entry
+      per line, either "<file-basename>=<rate>" (e.g. "debian_13=8", applies
+      to every data source detected in that file) or
+      "<file-basename>/<source>=<rate>" (e.g. "cpe_jvn/jvn-feed-rss=25",
+      single source, wins over the file key). The basename is the scan-result
+      file name without ".json". Blank/whitespace-only lines are dropped.
     required: false
     default: ""
   integration_ref:
     description: vulsio/integration commit SHA to pin scan-result fixtures to.
     required: false
-    default: 6547c4cb34bb42669b2f9bbc388d9b966b462c36
+    default: a612a993a1158c5079439adc4cb3422baaf595d8
   vuls0_old_ref:
     description: future-architect/vuls commit SHA for the older-binary detection check.
     required: false
@@ -263,10 +267,17 @@ runs:
         # still routes Windows to gost, so it does not exercise the vuls2 DB.
         # Drop windows from this older-binary set until `vuls0_old_ref` is
         # bumped past that change.
+        #
+        # cpe_* (pseudo servers with cpeNames) is likewise removed: the pinned
+        # older vuls0 predates "detect CPE with vuls2" and routes CPE URIs to
+        # an unconfigured go-cve-dictionary, which errors out. Drop these
+        # until `vuls0_old_ref` is bumped past the vuls2 CPE routing changes
+        # (NVD/VulnCheck/JVN/Fortinet/Cisco/PaloAlto).
         mkdir -p ./scan-results-old
         cp ./scan-results/*.json ./scan-results-old/
         rm -f \
-          ./scan-results-old/windows_*.json
+          ./scan-results-old/windows_*.json \
+          ./scan-results-old/cpe_*.json
         ls -1 ./scan-results-old
 
     - name: Diff detection with older vuls0 binary (baseline vs target DB)

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -268,11 +268,12 @@ runs:
         # Drop windows from this older-binary set until `vuls0_old_ref` is
         # bumped past that change.
         #
-        # cpe_* (pseudo servers with cpeNames) is likewise removed: the pinned
-        # older vuls0 predates "detect CPE with vuls2" and routes CPE URIs to
-        # an unconfigured go-cve-dictionary, which errors out. Drop these
-        # until `vuls0_old_ref` is bumped past the vuls2 CPE routing changes
-        # (NVD/VulnCheck/JVN/Fortinet/Cisco/PaloAlto).
+        # Every cpe_*.json (pseudo servers with cpeNames) is likewise removed:
+        # the pinned older vuls0 predates "detect CPE with vuls2" and routes
+        # CPE URIs to an unconfigured go-cve-dictionary, which errors out.
+        # Drop these until `vuls0_old_ref` is bumped past the commits that
+        # moved NVD, VulnCheck, JVN, Fortinet, Cisco and Palo Alto CPE
+        # detection to vuls2.
         mkdir -p ./scan-results-old
         cp ./scan-results/*.json ./scan-results-old/
         rm -f \

--- a/.github/diff-guard-override-grooming-issue.md
+++ b/.github/diff-guard-override-grooming-issue.md
@@ -12,7 +12,7 @@ The override lists were seeded (#152, #153) from a **failure-only** triage, whic
 
 **Input** — all `db-main` + `db-nightly` builds over the trailing ~2 months, **pass and fail alike**. PASS builds are the essential part: they are what reveal an override is no longer needed. The diff report prints a change-rate row for every target on every run, so each overridden target's full distribution over the window is directly observable.
 
-**Scope** — the whole override list is re-derived, not just appended to. The guard judges per (ecosystem, data source) for `diff db` and per (scan-result file, data source) for `diff detection`; override keys may be ecosystem-/file-wide (`<ecosystem>=<rate>`, `<file>=<rate>`) or slash-qualified to a single source (`cpe/cisco-json=30`, `cpe_jvn/jvn-feed-rss=25` — the narrower key wins). Prefer the narrowest key that covers the churn. For each existing entry, against the target's observed distribution over the window:
+**Scope** — the whole override list is re-derived, not just appended to. The guard judges per (ecosystem, data source) for `diff db` and per (scan-result file, data source) for `diff detection`; override keys may be ecosystem-/file-wide (`<ecosystem>=<rate>`, `<file-basename>=<rate>`) or slash-qualified to a single source (`cpe/cisco-json=30`, `cpe_jvn/jvn-feed-rss=25` — the narrower key wins). Prefer the narrowest key that covers the churn. For each existing entry, against the target's observed distribution over the window:
 
 - max observed ≤ the **default** threshold (db 10% / detection 5%) → **drop** the override;
 - would pass at a value below the current one → **narrow** it to (observed peak + headroom);

--- a/.github/diff-guard-override-grooming-issue.md
+++ b/.github/diff-guard-override-grooming-issue.md
@@ -12,7 +12,7 @@ The override lists were seeded (#152, #153) from a **failure-only** triage, whic
 
 **Input** — all `db-main` + `db-nightly` builds over the trailing ~2 months, **pass and fail alike**. PASS builds are the essential part: they are what reveal an override is no longer needed. The diff report prints a change-rate row for every target on every run, so each overridden target's full distribution over the window is directly observable.
 
-**Scope** — the whole override list is re-derived, not just appended to. For each existing entry, against the target's observed distribution over the window:
+**Scope** — the whole override list is re-derived, not just appended to. The guard judges per (ecosystem, data source) for `diff db` and per (scan-result file, data source) for `diff detection`; override keys may be ecosystem-/file-wide (`<ecosystem>=<rate>`, `<file>=<rate>`) or slash-qualified to a single source (`cpe/cisco-json=30`, `cpe_jvn/jvn-feed-rss=25` — the narrower key wins). Prefer the narrowest key that covers the churn. For each existing entry, against the target's observed distribution over the window:
 
 - max observed ≤ the **default** threshold (db 10% / detection 5%) → **drop** the override;
 - would pass at a value below the current one → **narrow** it to (observed peak + headroom);

--- a/.github/diff-guard-override-grooming-runbook.md
+++ b/.github/diff-guard-override-grooming-runbook.md
@@ -21,10 +21,19 @@ Two workflows run the diff guard, each on a 6-hour cron:
 
 Each workflow's `build` job carries two override lists in its `env:` block:
 
-- `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` — `<ecosystem>=<rate>` lines, for
-  `vuls diff db` (default threshold `DB_CHANGE_RATE_THRESHOLD`, 10%).
-- `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` — `<scan-result-file>=<rate>`
-  lines, for `vuls diff detection` (default `DETECTION_CHANGE_RATE_THRESHOLD`, 5%).
+- `DB_CHANGE_RATE_THRESHOLD_OVERRIDES` — for `vuls diff db` (default threshold
+  `DB_CHANGE_RATE_THRESHOLD`, 10%). Keys are `<ecosystem>` (all data sources
+  in that ecosystem) or `<ecosystem>/<source>` (a single source, e.g.
+  `cpe/cisco-json` — wins over the ecosystem key).
+- `DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES` — for `vuls diff detection`
+  (default `DETECTION_CHANGE_RATE_THRESHOLD`, 5%). Keys are
+  `<scan-result-file>` (all data sources detected in that file) or
+  `<scan-result-file>/<source>` (a single source, e.g.
+  `cpe_jvn/jvn-feed-rss` — wins over the file key).
+
+The guard judges pass/fail per (ecosystem, source) / (file, source) — "target"
+below means that pair, and the report prints one row per pair. Both key
+vocabularies use the vuls2 source IDs (e.g. `cisco-json`, `jvn-feed-rss`).
 
 Goal: re-derive both lists from the last ~2 months of data so they neither go
 stale (overrides for targets that have calmed down) nor miss newly-recurring
@@ -112,8 +121,12 @@ the report-table rows instead.
 The `Run diff guard` step prints a markdown report per diff. Column layouts vary
 slightly by `vuls` version, so read the header row to map columns. Typical:
 
-- **`vuls diff detection`** — `| Name | Baseline | Target | Added | Removed | Change Rate | [Threshold] | Result |`
-- **`vuls diff db`** — `| Ecosystem | Detection Change Rate | KB Change Rate | [Threshold] | Result |`
+- **`vuls diff detection`** — `| Name | Source | Baseline | Target | Added | Removed | Change Rate | [Threshold] | Result |`
+- **`vuls diff db`** — `| Ecosystem | Source | Detection Change Rate | KB Change Rate | [Threshold] | Result |`
+
+(Reports from vuls2 builds predating the per-source split lack the `Source`
+column and carry one row per ecosystem/file — map columns from the header row
+and treat those rows as the ecosystem-/file-wide aggregate.)
 
 For each sampled run, record per target: name, change rate(s), and Result
 (PASS / FAIL). The report lists *every* target, so one sampled run yields the
@@ -163,6 +176,10 @@ Edit the `env:` blocks in **both** `.github/workflows/db-main.yml` and
 - One `<key>=<rate>` per line. **No `#` comments inside the lists** — vuls2's
   override parser rejects them. Per-entry rationale goes in the PR description,
   not the YAML.
+- Prefer the **narrowest key that covers the churn**: if only one source in an
+  ecosystem (or in a file) is churning, use the slash-qualified key
+  (`cpe/jvn-feed-rss=…`, `cpe_jvn/jvn-feed-rss=…`) instead of loosening the
+  whole ecosystem/file — a wide key re-masks the other sources sharing it.
 - The two pipelines have independent data (different data branch, different
   `vuls` version, baseline-age effects), so their lists legitimately differ —
   but where the **same** target is overridden in both, keep the **value

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -7,18 +7,20 @@ on:
     inputs:
       db_change_rate_threshold:
         description: |
-          `vuls diff db` default change rate (%) threshold per ecosystem;
-          diff fails if exceeded. Leave empty to use the build job's
-          DB_CHANGE_RATE_THRESHOLD env; a value here replaces it for this
-          dispatch only.
+          `vuls diff db` default change rate (%) threshold per
+          (ecosystem, data source); diff fails if exceeded. Leave empty
+          to use the build job's DB_CHANGE_RATE_THRESHOLD env; a value
+          here replaces it for this dispatch only.
         required: false
         type: string
         default: ""
       db_change_rate_threshold_overrides:
         description: |
-          Per-ecosystem overrides of `vuls diff db` threshold, as
-          multi-line "<ecosystem>=<rate>" entries. Leave empty to use the
-          persistent list in the build job's
+          Overrides of `vuls diff db` threshold, as multi-line entries of
+          "<ecosystem>=<rate>" (all sources in the ecosystem) or
+          "<ecosystem>/<source>=<rate>" (single source, e.g.
+          "cpe/cisco-json=30", wins over the ecosystem key). Leave empty
+          to use the persistent list in the build job's
           DB_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty value here
           replaces it for this dispatch only. A whitespace-only value
           still counts as non-empty, so it replaces the env list with
@@ -31,17 +33,19 @@ on:
       detection_change_rate_threshold:
         description: |
           `vuls diff detection` default change rate (%) threshold per
-          scan result; diff fails if exceeded. Leave empty to use the
-          build job's DETECTION_CHANGE_RATE_THRESHOLD env; a value here
-          replaces it for this dispatch only.
+          (scan result, data source); diff fails if exceeded. Leave
+          empty to use the build job's DETECTION_CHANGE_RATE_THRESHOLD
+          env; a value here replaces it for this dispatch only.
         required: false
         type: string
         default: ""
       detection_change_rate_threshold_overrides:
         description: |
-          Per-scan-result-file overrides of `vuls diff detection`
-          threshold, as multi-line "<file-basename>=<rate>" entries.
-          Leave empty to use the persistent list in the build job's
+          Overrides of `vuls diff detection` threshold, as multi-line
+          entries of "<file-basename>=<rate>" (all data sources in the
+          file) or "<file-basename>/<source>=<rate>" (single source,
+          e.g. "cpe_jvn/jvn-feed-rss=25", wins over the file key). Leave empty to
+          use the persistent list in the build job's
           DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
           value here replaces it for this dispatch only. A
           whitespace-only value still counts as non-empty, so it

--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -44,8 +44,8 @@ on:
           Overrides of `vuls diff detection` threshold, as multi-line
           entries of "<file-basename>=<rate>" (all data sources in the
           file) or "<file-basename>/<source>=<rate>" (single source,
-          e.g. "cpe_jvn/jvn-feed-rss=25", wins over the file key). Leave empty to
-          use the persistent list in the build job's
+          e.g. "cpe_jvn/jvn-feed-rss=25", wins over the file key).
+          Leave empty to use the persistent list in the build job's
           DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
           value here replaces it for this dispatch only. A
           whitespace-only value still counts as non-empty, so it

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -7,18 +7,20 @@ on:
     inputs:
       db_change_rate_threshold:
         description: |
-          `vuls diff db` default change rate (%) threshold per ecosystem;
-          diff fails if exceeded. Leave empty to use the build job's
-          DB_CHANGE_RATE_THRESHOLD env; a value here replaces it for this
-          dispatch only.
+          `vuls diff db` default change rate (%) threshold per
+          (ecosystem, data source); diff fails if exceeded. Leave empty
+          to use the build job's DB_CHANGE_RATE_THRESHOLD env; a value
+          here replaces it for this dispatch only.
         required: false
         type: string
         default: ""
       db_change_rate_threshold_overrides:
         description: |
-          Per-ecosystem overrides of `vuls diff db` threshold, as
-          multi-line "<ecosystem>=<rate>" entries. Leave empty to use the
-          persistent list in the build job's
+          Overrides of `vuls diff db` threshold, as multi-line entries of
+          "<ecosystem>=<rate>" (all sources in the ecosystem) or
+          "<ecosystem>/<source>=<rate>" (single source, e.g.
+          "cpe/cisco-json=30", wins over the ecosystem key). Leave empty
+          to use the persistent list in the build job's
           DB_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty value here
           replaces it for this dispatch only. A whitespace-only value
           still counts as non-empty, so it replaces the env list with
@@ -31,17 +33,19 @@ on:
       detection_change_rate_threshold:
         description: |
           `vuls diff detection` default change rate (%) threshold per
-          scan result; diff fails if exceeded. Leave empty to use the
-          build job's DETECTION_CHANGE_RATE_THRESHOLD env; a value here
-          replaces it for this dispatch only.
+          (scan result, data source); diff fails if exceeded. Leave
+          empty to use the build job's DETECTION_CHANGE_RATE_THRESHOLD
+          env; a value here replaces it for this dispatch only.
         required: false
         type: string
         default: ""
       detection_change_rate_threshold_overrides:
         description: |
-          Per-scan-result-file overrides of `vuls diff detection`
-          threshold, as multi-line "<file-basename>=<rate>" entries.
-          Leave empty to use the persistent list in the build job's
+          Overrides of `vuls diff detection` threshold, as multi-line
+          entries of "<file-basename>=<rate>" (all data sources in the
+          file) or "<file-basename>/<source>=<rate>" (single source,
+          e.g. "cpe_jvn/jvn-feed-rss=25", wins over the file key). Leave empty to
+          use the persistent list in the build job's
           DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
           value here replaces it for this dispatch only. A
           whitespace-only value still counts as non-empty, so it

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -44,8 +44,8 @@ on:
           Overrides of `vuls diff detection` threshold, as multi-line
           entries of "<file-basename>=<rate>" (all data sources in the
           file) or "<file-basename>/<source>=<rate>" (single source,
-          e.g. "cpe_jvn/jvn-feed-rss=25", wins over the file key). Leave empty to
-          use the persistent list in the build job's
+          e.g. "cpe_jvn/jvn-feed-rss=25", wins over the file key).
+          Leave empty to use the persistent list in the build job's
           DETECTION_CHANGE_RATE_THRESHOLD_OVERRIDES env; a non-empty
           value here replaces it for this dispatch only. A
           whitespace-only value still counts as non-empty, so it


### PR DESCRIPTION
## Why

The diff guard's two upstream pieces landed:

- **MaineK00n/vuls2#400** — `vuls diff db` judges per (ecosystem, data source) and `vuls diff detection` per (scan-result file, data source), with slash-qualified override keys. Already live here since the merge (this repo installs `vuls@nightly` at run time).
- **vulsio/integration#43** — CPE pseudo-server fixtures, one file per cpe data source (`cpe_nvd`, `cpe_jvn`, `cpe_cisco`, `cpe_fortinet`, `cpe_paloalto`, `cpe_kernel`).

This PR wires the fixtures in and updates the docs to the new key vocabulary.

## What

- `integration_ref` default → `a612a99` (vulsio/integration#43). The `cpe_*` fixtures enter the master-HEAD detection check.
- The older-vuls0 detection step additionally drops `cpe_*.json`: the pinned `vuls0_old_ref` (3266337) predates CPE-via-vuls2 routing (future-architect/vuls@f621477 and earlier commits) and would route the CPE URIs to an unconfigured go-cve-dictionary, erroring the step. Lift the exclusion when the pin is bumped past that.
- Input/dispatch descriptions and the grooming runbook/issue now document both key forms — `<ecosystem>=<rate>` / `<ecosystem>/<source>=<rate>` and `<file-basename>=<rate>` / `<file-basename>/<source>=<rate>` — plus the narrowest-key guidance (a wide key re-masks the other sources sharing it). The override parser is untouched; keys are opaque.

## Deliberately not included

No new override seeds. Per-source rates should be observed on real runs first, then seeded from measured values. Known candidates from local runs against real digest pairs:

- `cpe_fortinet/fortinet-csaf` — the whole source holds only 158 roots, so its per-file baseline caps at ~37 CVEs; single-advisory churn can cross 5%.
- `cpe/jvn-feed-rss` (db side) — 583k criterions with rolling-feed churn; measure before seeding.

## Validation

- `actionlint` clean on both workflows.
- The per-source guard itself was validated against the failed run https://github.com/vulsio/vuls-data-db/actions/runs/28987458616's digest pair: `diff db` pinpoints `cpe / vulncheck-nist-nvd2` at 189.6% (the shipped guard could only say "cpe 28.9%"), and the `cpe_*` fixtures expose the same event as a 60–75% vulncheck detection loss that the file-level CVE-set diff had passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)