### PR TITLE
feat(ci/alma-oval): enable alma-oval extract and add it to the DB build

### DIFF
--- a/.github/workflows/extract-all.yml
+++ b/.github/workflows/extract-all.yml
@@ -24,7 +24,7 @@ jobs:
         target:
           - "alma-errata"
           - "alma-osv"
-          # - "alma-oval"
+          - "alma-oval"
           - "alpine-secdb"
           - "alpine-osv"
           - "amazon"
@@ -160,7 +160,7 @@ jobs:
         target:
           - "alma-errata"
           - "alma-osv"
-          # - "alma-oval"
+          - "alma-oval"
           - "alpine-secdb"
           - "alpine-osv"
           - "amazon"

--- a/.github/workflows/extract-main.yml
+++ b/.github/workflows/extract-main.yml
@@ -19,7 +19,7 @@ on:
         options:
           - alma-errata
           - alma-osv
-          # - alma-oval
+          - alma-oval
           - alpine-secdb
           - alpine-osv
           - amazon

--- a/db-main.mk
+++ b/db-main.mk
@@ -7,6 +7,7 @@ DBPATH := ~/.cache/vuls/vuls.db
 db-build:
 	vuls db init --dbtype ${DBTYPE} --dbpath ${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-oval BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}

--- a/db-nightly.mk
+++ b/db-nightly.mk
@@ -7,6 +7,7 @@ DBPATH := ~/.cache/vuls/vuls.db
 db-build:
 	vuls db init --dbtype ${DBTYPE} --dbpath ${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-errata BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alma-oval BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-alpine-secdb BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-amazon BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	$(MAKE) -f ${MAKEFILE} db-add REPO=vuls-data-extracted-cisa-kev BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
## Summary

Enables the alma-oval pipeline end to end, as the second alma datasource alongside alma-errata:

- `.github/workflows/extract-all.yml` (main + nightly matrices) / `.github/workflows/extract-main.yml`: uncomment `alma-oval` (the fetch side has been running all along; only extract was disabled because the extractor was a stub)
- `db-main.mk` / `db-nightly.mk`: add `db-add REPO=vuls-data-extracted-alma-oval`

## Why

AlmaLinux OVAL carries the full historical package criteria (epoch-complete EVRs) that `errata.full.json` dropped for previous-minor packages during the upstream re-curations, and upstream explicitly recommends OVAL for historical data (https://bugs.almalinux.org/view.php?id=644#c1231). The two sources cover each other's gaps (OVAL misses the 2026-05-26 re-issue cohort; the feed misses historical criteria — e.g. ALSA-2026:2721 kernel: 2 packages in the feed vs 75 criteria in OVAL). `vuls diff detection` alma_10 removed=97 from the unpin (#192) is expected to be recovered by this.

## Dependencies / ordering (why draft)

1. ⏳ vuls-data-update extractor PR (implements `pkg/extract/alma/oval`, currently a no-op stub) must merge first — extract jobs `go install` vuls-data-update@main
2. Then run extract alma-oval (both main and nightly variants) to populate `vuls-data-extracted-alma-oval` (truncated/empty since 2024-07)
3. Then this PR's db-add lines can succeed
4. First DB / DB(Nightly) runs will trip diff-guard on the alma baseline jump (detections roughly double) → usual promote

## Verification

- actionlint: only pre-existing SC2086 infos in `extract-all.yml`'s summary step (untouched)
- `make -n` dry-runs show the new db-add step for both makefiles
- Extractor validated locally against the real raw dotgit: 3,928 advisories (8/9/10 merged), alma:10 = 468 defs, ALSA-2026:2721 yields 75 epoch-complete criteria, A-series and modular (`idm:DL1::...`) handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)