### PR TITLE
chore(ci): drop alma-osv and alpine-osv from extract matrices

### DIFF
--- a/.github/workflows/extract-all.yml
+++ b/.github/workflows/extract-all.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         target:
           - "alma-errata"
-          # - "alma-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
+          # - "alma-osv"
           # - "alma-oval"
           - "alpine-secdb"
-          # - "alpine-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
+          # - "alpine-osv"
           - "amazon"
           # - "android-osv"
           - "arch"
@@ -159,10 +159,10 @@ jobs:
       matrix:
         target:
           - "alma-errata"
-          # - "alma-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
+          # - "alma-osv"
           # - "alma-oval"
           - "alpine-secdb"
-          # - "alpine-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
+          # - "alpine-osv"
           - "amazon"
           # - "android-osv"
           - "arch"

--- a/.github/workflows/extract-all.yml
+++ b/.github/workflows/extract-all.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         target:
           - "alma-errata"
-          - "alma-osv"
+          # - "alma-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
           # - "alma-oval"
           - "alpine-secdb"
-          - "alpine-osv"
+          # - "alpine-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
           - "amazon"
           # - "android-osv"
           - "arch"
@@ -159,10 +159,10 @@ jobs:
       matrix:
         target:
           - "alma-errata"
-          - "alma-osv"
+          # - "alma-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
           # - "alma-oval"
           - "alpine-secdb"
-          - "alpine-osv"
+          # - "alpine-osv" # extractor is not implemented yet (stub since MaineK00n/vuls-data-update#177)
           - "amazon"
           # - "android-osv"
           - "arch"


### PR DESCRIPTION
## What

Comments out `alma-osv` and `alpine-osv` in both the `extract-main` and `extract-main-nightly` matrices of `extract-all.yml`, in the same style as the other disabled targets. Fetch jobs are kept as-is (raw repositories are healthy and updated daily).

## Why

Their extractors in vuls-data-update are stubs: since the extract types change (MaineK00n/vuls-data-update#177), `pkg/extract/alma/osv` and `pkg/extract/alpine/osv` walk the raw repository and write nothing. Evidence:

- `vuls-data-extracted-alma-osv` / `vuls-data-extracted-alpine-osv` have HEAD pointing at the **empty tree** since 2024-07 (the types-change commit deleted the old-format data and nothing has been written since).
- In recent extract-all runs the extract step finishes in ~50ms with no output (e.g. run 29235174298, job 86768074480), then the commit step finds no changes; the jobs "succeed" while producing nothing.
- Both `Extract()` bodies are `WalkDir` loops whose every branch is `return nil`.

Dropping them from the matrices stops burning CI time on no-op jobs. Re-add the targets once the extractors are implemented.

Found while running a new semantic validator (`vuls data validate`, MaineK00n/vuls2#402) across all extract-enabled dotgits: these two were the only ones whose working tree could not even be restored (`git restore .` fails on an empty tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)