### PR TITLE
feat(ci): annotate pushed vuls.db manifests with build provenance

### DIFF
--- a/.github/workflows/db-main.yml
+++ b/.github/workflows/db-main.yml
@@ -172,7 +172,17 @@ jobs:
           SCHEMA_VERSION: ${{ steps.save_schema_version.outputs.schema_version }}
         run: |
           set -euo pipefail
-          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" ghcr.io/vulsio/vuls-nightly-db ./vuls.db.zst)
+          # Annotations identify which pipeline produced an (initially
+          # untagged) candidate digest; they are readable without pulling
+          # the 250MB layer:
+          #   oras manifest fetch ghcr.io/vulsio/vuls-nightly-db@<digest> | jq .annotations
+          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" \
+            --annotation "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "org.opencontainers.image.revision=${{ github.sha }}" \
+            --annotation "io.vuls.db.branch=main" \
+            --annotation "io.vuls.db.schema-version=${SCHEMA_VERSION}" \
+            --annotation "io.vuls.db.build.run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" \
+            ghcr.io/vulsio/vuls-nightly-db ./vuls.db.zst)
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
           {
             echo "## Pushed candidate image (untagged, digest-only)"

--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -156,6 +156,10 @@ jobs:
       - name: Build DB
         run: make -f db-nightly.mk db-build BRANCH=nightly DBPATH=./vuls.db
 
+      - name: Save vuls.db schema_version
+        id: save_schema_version
+        run: echo "schema_version=$(vuls db search metadata --dbpath ./vuls.db | jq .schema_version)" >> "$GITHUB_OUTPUT"
+
       - name: Compact vuls.db
         run: vuls db compress --dbpath ./vuls.db
 
@@ -166,9 +170,21 @@ jobs:
       # step below passes.
       - name: Push vuls.db to GHCR (tagless, digest-only)
         id: push
+        env:
+          SCHEMA_VERSION: ${{ steps.save_schema_version.outputs.schema_version }}
         run: |
           set -euo pipefail
-          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" ghcr.io/vulsio/vuls-nightly-db ./vuls.db.zst)
+          # Annotations identify which pipeline produced an (initially
+          # untagged) candidate digest; they are readable without pulling
+          # the 250MB layer:
+          #   oras manifest fetch ghcr.io/vulsio/vuls-nightly-db@<digest> | jq .annotations
+          digest=$(vuls db push --token "${{ secrets.GITHUB_TOKEN }}" \
+            --annotation "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "org.opencontainers.image.revision=${{ github.sha }}" \
+            --annotation "io.vuls.db.branch=nightly" \
+            --annotation "io.vuls.db.schema-version=${SCHEMA_VERSION}" \
+            --annotation "io.vuls.db.build.run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" \
+            ghcr.io/vulsio/vuls-nightly-db ./vuls.db.zst)
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
           {
             echo "## Pushed candidate image (untagged, digest-only)"


### PR DESCRIPTION
## Background

Both db-main.yml and db-nightly.yml push tagless candidate images to the same package (`ghcr.io/vulsio/vuls-nightly-db`), so the untagged digests listed on the GHCR package version page cannot be told apart: which pipeline produced them, which schema version they carry, or which workflow run built them. GHCR's UI does not display OCI annotations, so the goal is not "visible at a glance" but "resolvable with one command from a copied digest".

## Changes

Pass OCI manifest annotations at push time via `vuls db push --annotation` (added in MaineK00n/vuls2#413):

| key | value |
|---|---|
| `org.opencontainers.image.source` | `${{ github.server_url }}/${{ github.repository }}` |
| `org.opencontainers.image.revision` | `${{ github.sha }}` |
| `io.vuls.db.branch` | `main` / `nightly` (static per workflow; the make `BRANCH=` / `go install` ref) |
| `io.vuls.db.schema-version` | read from the built DB before compression |
| `io.vuls.db.build.run-url` | `.../actions/runs/<run_id>/attempts/<run_attempt>` — reverse lookup from a candidate digest to the run that produced it |

(`org.opencontainers.image.created` is auto-added by oras PackManifest v1.1 and needs no work.)

- db-nightly.yml gains the same `Save vuls.db schema_version` step that db-main.yml already has. It must run **before** `vuls db compress`, which replaces the DB file with the zstd archive.
- Annotations survive promotion unchanged: `promote-digest.yml` / `dotgit registry tag` only move tags onto digests and never touch the manifest, so no changes there.

Readout (candidate or promoted alike):

```sh
oras manifest fetch ghcr.io/vulsio/vuls-nightly-db@sha256:... | jq .annotations
```

## Notes

- Annotations are part of the manifest digest computation, and `run-url` changes per run, so identical DB content now yields a different manifest digest per build. DB content already changes every 6h, so nothing is lost in practice.
- Existing untagged versions are not annotated retroactively.
- **Merge order**: depends on MaineK00n/vuls2#413 — `vuls db push` must support `--annotation` on the branches the workflows install from (`go install ...@main|@nightly`), otherwise the push step fails. Keeping this PR draft until vuls2#413 lands in both branches.

## Validation

- `actionlint .github/workflows/db-main.yml .github/workflows/db-nightly.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)