### PR TITLE
feat(diff-guard): add memory telemetry to the heavy diff steps

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -58,6 +58,19 @@ description: |
     rendered as `MISSING` in the summary table, surfaced as `?` in the
     diagnostic line, and counted as failure (exit rc=1).
 
+  Memory telemetry:
+    Several DB runs have been killed mid-diff-guard with SIGTERM
+    (exit 143, run shown as "cancelled", no cancelling actor in the
+    audit log) — the signature of the hosted runner VM becoming
+    unhealthy under memory pressure, not of a threshold trip. Each
+    heavy diff step therefore runs memmon.sh (same directory) as an
+    in-step sidecar streaming `[memmon]`/`[oom-watch]` lines into the
+    step log, and passes `--debug` to `vuls diff` so per-task
+    start/done lines (scan-result file + role, or ecosystem) land in
+    the same timestamped log for correlation. See memmon.sh's header
+    for the design constraints (stdout-only, fork-free sampling) and
+    for how to read the lines.
+
 inputs:
   target_db:
     description: Path to the freshly built vuls.db to validate.
@@ -209,6 +222,13 @@ runs:
         set +e
         set -o pipefail
 
+        # Memory telemetry sidecar; see the `Memory telemetry` section
+        # in the action description. `--debug` below makes `vuls diff`
+        # emit per-task start/done lines (stderr, so the tee'd report
+        # stays clean) that correlate with the sidecar's samples.
+        "${{ github.action_path }}/memmon.sh" &
+        memmon_pid=$!
+
         # `$OVERRIDES_CSV` comes from the `Parse threshold overrides`
         # step. Passed verbatim: vuls2's StringSlice flag parses an empty
         # value into an empty override list, so the no-overrides path
@@ -219,8 +239,10 @@ runs:
           "$TARGET_DB" "$VULS0" \
           --change-rate-threshold "$DETECTION_CHANGE_RATE_THRESHOLD" \
           --change-rate-threshold-override "$OVERRIDES_CSV" \
+          --debug \
           | tee ./diff-detection-report.md
         rc=$?
+        kill "$memmon_pid" 2>/dev/null
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
         echo "## Diff detection (vuls0 master HEAD) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
@@ -296,6 +318,10 @@ runs:
         set +e
         set -o pipefail
 
+        # Memory telemetry sidecar + `--debug`; see diff_detection_master.
+        "${{ github.action_path }}/memmon.sh" &
+        memmon_pid=$!
+
         # `$OVERRIDES_CSV` comes from the `Parse threshold overrides`
         # step. See diff_detection_master for the verbatim-pass rationale.
         vuls diff detection \
@@ -304,8 +330,10 @@ runs:
           "$TARGET_DB" "$VULS0_OLD" \
           --change-rate-threshold "$DETECTION_CHANGE_RATE_THRESHOLD" \
           --change-rate-threshold-override "$OVERRIDES_CSV" \
+          --debug \
           | tee ./diff-detection-old-report.md
         rc=$?
+        kill "$memmon_pid" 2>/dev/null
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
         echo "## Diff detection (older pinned vuls0 @${VULS0_OLD_REF:0:7}) — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"
@@ -331,13 +359,19 @@ runs:
         set +e
         set -o pipefail
 
+        # Memory telemetry sidecar + `--debug`; see diff_detection_master.
+        "${{ github.action_path }}/memmon.sh" &
+        memmon_pid=$!
+
         # `$OVERRIDES_CSV` comes from the `Parse threshold overrides`
         # step. See diff_detection_master for the verbatim-pass rationale.
         vuls diff db ./baseline.db "$TARGET_DB" \
           --change-rate-threshold "$DB_CHANGE_RATE_THRESHOLD" \
           --change-rate-threshold-override "$OVERRIDES_CSV" \
+          --debug \
           | tee ./diff-report.md
         rc=$?
+        kill "$memmon_pid" 2>/dev/null
 
         echo "---" >> "$GITHUB_STEP_SUMMARY"
         echo "## Diff vuls.db — rc=${rc}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/diff-guard/memmon.sh
+++ b/.github/actions/diff-guard/memmon.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Memory-telemetry sidecar for the heavy diff steps in the diff-guard
+# action. Streams to stdout: one cheap sample line every 3s, a
+# per-process breakdown every 15s, and kernel ring-buffer lines
+# ([oom-watch], OOM-killer evidence) as they appear.
+#
+# Why stdout and not a file/artifact: the runs this exists for are the
+# ones the hosted runner kills mid-step (SIGTERM/exit 143, run shown as
+# "cancelled"); on such a kill every later step is skipped, so an
+# upload-artifact step would never run. Lines already streamed to the
+# step log survive, and the runner timestamps each one.
+#
+# Why the cheap sample forks nothing: when memory is nearly exhausted,
+# fork/exec of external tools (`free`, `ps`) is exactly what starts
+# failing, which would silence the monitor at the moment of interest.
+# The 3s line uses bash builtins reading /proc only; the fork-heavy
+# per-process breakdown runs at a slower cadence and may drop out under
+# pressure without losing the primary signal.
+#
+# Reading the output:
+#   - avail/swapfree are instantaneous, 3s resolution.
+#   - pgmajfault/pswpout are cumulative kernel counters: deltas between
+#     consecutive lines expose thrashing that happened between samples,
+#     so nothing is lost to the sampling interval.
+#   - psi(some) is /proc/pressure/memory: avg10 integrates the last 10s
+#     of memory stall time, surviving spikes shorter than the interval.
+#   - Per-process rss overcounts shared pages (each worker maps the
+#     same multi-GiB bolt DB); anon (RssAnon) is the unreclaimable heap
+#     and is the number that actually crowds the VM.
+set -u
+
+cleanup() {
+  trap - TERM INT EXIT
+  # The dmesg watcher is root-owned (sudo), so a plain kill would get
+  # EPERM; route its kill through sudo. Its sed prefixer then exits on
+  # EOF by itself.
+  if [ -n "${dmesg_pid:-}" ]; then
+    sudo -n kill "$dmesg_pid" 2>/dev/null
+  fi
+  jobs -p | xargs -r kill 2>/dev/null
+  exit 0
+}
+trap cleanup TERM INT EXIT
+
+# Kernel OOM-killer evidence must already be streaming when the step
+# dies — there is no later opportunity to run `dmesg` after a cancel.
+# --follow-new, not --follow: only new messages, not the whole boot
+# ring buffer. Process substitution rather than a pipeline so $! is
+# the sudo/dmesg process itself (the one needing the sudo kill above).
+dmesg_pid=""
+if sudo -n true 2>/dev/null; then
+  # shellcheck disable=SC2024 # the step log (our stdout) is the intended sink
+  sudo -n dmesg --follow-new 2>/dev/null > >(sed -u 's/^/[oom-watch] /') &
+  dmesg_pid=$!
+fi
+
+# Builtin-only sleep: `read -t` on a FIFO opened read-write never sees
+# data, so it just times out — no per-iteration fork (see header note).
+fifo=$(mktemp -u)
+mkfifo "$fifo"
+exec 9<>"$fifo"
+rm -f "$fifo"
+
+i=0
+while :; do
+  avail=0 swapfree=0
+  while read -r key value _; do
+    case "$key" in
+      MemAvailable:) avail=$((value / 1024)) ;;
+      SwapFree:) swapfree=$((value / 1024)) ;;
+    esac
+  done </proc/meminfo
+
+  pgmajfault=0 pswpout=0
+  while read -r key value; do
+    case "$key" in
+      pgmajfault) pgmajfault=$value ;;
+      pswpout) pswpout=$value ;;
+    esac
+  done </proc/vmstat
+
+  psi=""
+  if [ -r /proc/pressure/memory ]; then
+    read -r _ psi _ </proc/pressure/memory
+  fi
+
+  echo "[memmon] avail=${avail}MiB swapfree=${swapfree}MiB${psi:+ psi(some) ${psi}} pgmajfault=${pgmajfault} pswpout=${pswpout}"
+
+  # Fork-heavy per-process breakdown, every 5th sample. Covers the
+  # diff driver (vuls) and both detection worker binaries.
+  if ((i % 5 == 0)); then
+    ps -C vuls,vuls0,vuls0-old -o pid=,comm=,etimes=,rss= 2>/dev/null |
+      while read -r pid comm etimes rss; do
+        anon=$(awk '/^RssAnon:/ {print int($2 / 1024)}' "/proc/${pid}/status" 2>/dev/null)
+        echo "[memmon]   ${comm} pid=${pid} up=${etimes}s rss=$((rss / 1024))MiB anon=${anon:-?}MiB"
+      done
+  fi
+
+  i=$((i + 1))
+  read -r -t 3 -u 9 _ || :
+done

--- a/.github/actions/diff-guard/memmon.sh
+++ b/.github/actions/diff-guard/memmon.sh
@@ -56,10 +56,13 @@ fi
 
 # Builtin-only sleep: `read -t` on a FIFO opened read-write never sees
 # data, so it just times out — no per-iteration fork (see header note).
-fifo=$(mktemp -u)
-mkfifo "$fifo"
-exec 9<>"$fifo"
-rm -f "$fifo"
+# The FIFO lives in a fresh mktemp -d directory (created atomically,
+# mode 0700) rather than at a mktemp -u name, so no other process can
+# race the path; it is unlinked as soon as fd 9 holds it open.
+fifo_dir=$(mktemp -d)
+mkfifo "$fifo_dir/tick"
+exec 9<>"$fifo_dir/tick"
+rm -rf "$fifo_dir"
 
 i=0
 while :; do

--- a/.github/actions/diff-guard/memmon.sh
+++ b/.github/actions/diff-guard/memmon.sh
@@ -33,9 +33,18 @@ cleanup() {
   trap - TERM INT EXIT
   # The dmesg watcher is root-owned (sudo), so a plain kill would get
   # EPERM; route its kill through sudo. Its sed prefixer then exits on
-  # EOF by itself.
-  if [ -n "${dmesg_pid:-}" ]; then
-    sudo -n kill "$dmesg_pid" 2>/dev/null
+  # EOF by itself. Guard against PID reuse (the watcher may have exited
+  # early, e.g. unsupported dmesg option): only kill if the PID is
+  # still a child of this script whose comm is sudo/dmesg.
+  # /proc/<pid>/stat reads "pid (comm) state ppid ..."; comm for
+  # sudo/dmesg contains no spaces, so a whitespace read is safe here.
+  if [ -n "${dmesg_pid:-}" ] && [ -r "/proc/${dmesg_pid}/stat" ]; then
+    read -r _ watcher_comm _ watcher_ppid _ <"/proc/${dmesg_pid}/stat" || watcher_ppid=""
+    if [ "$watcher_ppid" = "$$" ]; then
+      case "$watcher_comm" in
+        "(sudo)" | "(dmesg)") sudo -n kill "$dmesg_pid" 2>/dev/null ;;
+      esac
+    fi
   fi
   jobs -p | xargs -r kill 2>/dev/null
   exit 0


### PR DESCRIPTION
## Why

Three DB runs (2026-06-09, 2026-07-19, 2026-07-24) were killed mid-`Run diff guard` with SIGTERM (`Process completed with exit code 143`), the run showing as **cancelled** with no cancelling actor in the org audit log. That combination is the signature of the hosted runner VM becoming unhealthy under memory pressure and being cancelled server-side — not a threshold trip, and not a human cancel.

Circumstantial evidence points at memory:

- All three kills landed in the diff-guard phase (~20% of job wall time), most right after `Starting vuls0 detection ... workers=4`.
- The compacted `vuls.db` has roughly doubled since May: 5.74 GiB (05-05) → 6.42 (06-05) → 10.74 (07-03) → 11.11 GiB (07-24), and the unexplained-cancel count tracks it (May 0, June 1, July 2).
- Detection runs 4 concurrent `vuls0` workers against two ~11 GiB DBs (baseline + target) on a 16 GB runner.

This PR adds the telemetry to confirm (or refute) that before touching worker counts.

## What

- **`memmon.sh`** — in-step sidecar started (and killed after `rc` capture) in each of the three heavy diff steps:
  - every 3s, a fork-free sample read from `/proc` with bash builtins only (`MemAvailable`, `SwapFree`, PSI `some avg10`, cumulative `pgmajfault`/`pswpout`) — fork-free so it keeps reporting when memory is nearly exhausted and `fork`/`exec` starts failing;
  - every 15s, per-process `rss` + `RssAnon` for `vuls` / `vuls0` / `vuls0-old`;
  - a `dmesg --follow-new` watcher streaming kernel OOM-killer evidence as `[oom-watch]` lines.
- **`--debug` on the `vuls diff` invocations** — per-task start/done lines (scan-result file + role, or ecosystem) go to stderr, so the tee'd reports and step summaries stay clean, while the timestamped step log gains the join key between memory samples and in-flight tasks.

Everything streams to the step log on purpose: on a job-level cancel every later step is skipped, so an `upload-artifact` step would never run, while already-streamed lines survive (verified on the 07-24 run, whose log retains lines up to the SIGTERM instant).

Cumulative counters (`pgmajfault`/`pswpout`) and the 10s-integrated PSI figure make the data robust to spikes shorter than the sampling interval; deltas between consecutive lines expose thrashing that happened between samples.

## Verification

- `shellcheck` / `bash -n` clean; `actionlint` reports nothing new (two pre-existing SC2129 style notes in an untouched workflow).
- Ran `memmon.sh` locally: 3s cadence confirmed, per-process line verified against a `vuls0`-named dummy, and after SIGTERM neither the monitor nor the root-owned `dmesg` leaks (dmesg is killed via `sudo -n kill`; a plain kill would get EPERM).
- `--follow-new` (util-linux ≥ 2.37, present on ubuntu-latest) is used instead of `--follow`, which would dump the entire boot ring buffer first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)