### PR TITLE
fix(diff-guard): cap vuls0 heap with GOMEMLIMIT=3GiB on detection steps

### DIFF
--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -58,6 +58,23 @@ description: |
     rendered as `MISSING` in the summary table, surfaced as `?` in the
     diagnostic line, and counted as failure (exit rc=1).
 
+  Memory budget:
+    `vuls diff detection` fans out up to NumCPU (4 on hosted runners)
+    concurrent vuls0 processes, each detecting one scan-result file
+    against an ~11 GiB DB. Task order is randomized (Go map iteration),
+    and profiling against the 2026-07-24 DB pair showed 16 of 150 tasks
+    peak above 3 GiB of anonymous memory (sles15 alone peaks at ~6 GiB;
+    live heap ~3 GiB, the rest GC slack). An unlucky co-schedule of the
+    heaviest tasks sums to ~18 GiB anon — past the 16 GiB runner — which
+    evicts the page cache, thrashes, and gets the job cancelled
+    server-side (runs on 2026-06-09 / 07-19 / 07-24 died this way:
+    SIGTERM mid-detection, "cancelled", no cancelling actor).
+    GOMEMLIMIT=3GiB on the detection steps caps each vuls0 at ~3.6 GiB
+    anon (worst-case 4-task sum ~13.7 GiB, inside budget) at the cost of
+    extra GC only in the few tasks that exceed the limit (~+11% on the
+    step, measured). `vuls diff db` is a single process and is left
+    uncapped.
+
 inputs:
   target_db:
     description: Path to the freshly built vuls.db to validate.
@@ -202,6 +219,11 @@ runs:
         TARGET_DB: ${{ inputs.target_db }}
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
         OVERRIDES_CSV: ${{ steps.parse_overrides.outputs.detection_csv }}
+        # Caps each vuls0 worker's Go heap so an unlucky co-schedule of
+        # the heaviest scan-result files stays inside the 16 GiB runner.
+        # Inherited by the vuls0 child processes via the environment.
+        # See the `Memory budget` section in the action description.
+        GOMEMLIMIT: 3GiB
       run: |
         # No `set -e` after `rc=$?` — the rest of the step must reach
         # the final `echo "rc=..." >> $GITHUB_OUTPUT` so the aggregator
@@ -291,6 +313,8 @@ runs:
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
         OVERRIDES_CSV: ${{ steps.parse_overrides.outputs.detection_csv }}
         VULS0_OLD_REF: ${{ inputs.vuls0_old_ref }}
+        # See diff_detection_master and the `Memory budget` section.
+        GOMEMLIMIT: 3GiB
       run: |
         # Stay in `set +e` for the entire step. See note above.
         set +e

--- a/.github/actions/diff-guard/action.yml
+++ b/.github/actions/diff-guard/action.yml
@@ -59,9 +59,10 @@ description: |
     diagnostic line, and counted as failure (exit rc=1).
 
   Memory budget:
-    `vuls diff detection` fans out up to NumCPU (4 on hosted runners)
-    concurrent vuls0 processes, each detecting one scan-result file
-    against an ~11 GiB DB. Task order is randomized (Go map iteration),
+    `vuls diff detection` fans out up to NumCPU concurrent vuls0
+    processes (currently 4 on the standard ubuntu-latest runners this
+    repo builds on), each detecting one scan-result file against an
+    ~11 GiB DB. Task order is randomized (Go map iteration),
     and profiling against the 2026-07-24 DB pair showed 16 of 150 tasks
     peak above 3 GiB of anonymous memory (sles15 alone peaks at ~6 GiB;
     live heap ~3 GiB, the rest GC slack). An unlucky co-schedule of the
@@ -69,11 +70,12 @@ description: |
     evicts the page cache, thrashes, and gets the job cancelled
     server-side (runs on 2026-06-09 / 07-19 / 07-24 died this way:
     SIGTERM mid-detection, "cancelled", no cancelling actor).
-    GOMEMLIMIT=3GiB on the detection steps caps each vuls0 at ~3.6 GiB
-    anon (worst-case 4-task sum ~13.7 GiB, inside budget) at the cost of
-    extra GC only in the few tasks that exceed the limit (~+11% on the
-    step, measured). `vuls diff db` is a single process and is left
-    uncapped.
+    GOMEMLIMIT=3GiB on the detection steps is a soft target for the Go
+    heap, not a hard cap on process memory; in profiling it kept each
+    vuls0 around ~3.6 GiB anon (worst-case 4-task sum ~13.7 GiB, inside
+    budget) at the cost of extra GC only in the few tasks whose natural
+    heap exceeds the target (~+11% on the step, measured). `vuls diff
+    db` is a single process and is left unlimited.
 
 inputs:
   target_db:
@@ -219,10 +221,11 @@ runs:
         TARGET_DB: ${{ inputs.target_db }}
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
         OVERRIDES_CSV: ${{ steps.parse_overrides.outputs.detection_csv }}
-        # Caps each vuls0 worker's Go heap so an unlucky co-schedule of
-        # the heaviest scan-result files stays inside the 16 GiB runner.
-        # Inherited by the vuls0 child processes via the environment.
-        # See the `Memory budget` section in the action description.
+        # Soft-limits each vuls0 worker's Go heap so an unlucky
+        # co-schedule of the heaviest scan-result files stays inside
+        # the 16 GiB runner. Inherited by the vuls0 child processes via
+        # the environment. See the `Memory budget` section in the
+        # action description.
         GOMEMLIMIT: 3GiB
       run: |
         # No `set -e` after `rc=$?` — the rest of the step must reach
@@ -313,7 +316,7 @@ runs:
         DETECTION_CHANGE_RATE_THRESHOLD: ${{ inputs.detection_change_rate_threshold }}
         OVERRIDES_CSV: ${{ steps.parse_overrides.outputs.detection_csv }}
         VULS0_OLD_REF: ${{ inputs.vuls0_old_ref }}
-        # See diff_detection_master and the `Memory budget` section.
+        # See the `Memory budget` section in the action description.
         GOMEMLIMIT: 3GiB
       run: |
         # Stay in `set +e` for the entire step. See note above.


### PR DESCRIPTION
## Why

Three DB runs (2026-06-09, 2026-07-19, 2026-07-24) were killed mid-`Run diff guard` with SIGTERM (exit 143), shown as **cancelled** with no cancelling actor in the org audit log — the signature of the hosted runner VM becoming unhealthy under memory pressure and being cancelled server-side.

Local profiling against the 2026-07-24 run's exact DB pair (baseline `:0` @ `sha256:51b861da…`, candidate @ `sha256:6963fb08…`, the pinned integration fixtures, vuls2 @main / vuls0 @master) established the mechanism:

- Detection fans out `min(NumCPU, tasks)` = **4 concurrent vuls0 workers** in **randomized task order** (Go map iteration), 150 tasks total.
- **16 of 150 tasks peak above 3 GiB of anonymous memory**. The worst, `sles15`, peaks at **~5.9 GiB anon** (live heap is only ~3.0 GiB — the rest is GC slack). Next tier (`ubuntu_2004`, `oracle_9`, `sles12`, `debian_*`) sits at 3.0–3.5 GiB. The `cpe_*` fixtures are not the drivers (only `cpe_kernel` is moderately heavy at ~2.6 GiB).
- An unlucky co-schedule of the heaviest 4 tasks sums to **~18 GiB anon on a 16 GiB runner**. Replaying that collision in a 14 GiB cgroup (16 GiB minus OS/runner overhead, 4 GiB swap) wiped the page cache down to ~2 MB (every bolt access became a major fault — 120k+ faults on a single task), pushed 2.3 GiB into swap, forced reclaim 17k times and drove memory PSI above 13%. On Azure disk speeds that stall starves the runner heartbeat → server-side cancel. Randomized ordering explains why most runs survive and these three didn't.

## What

Set **`GOMEMLIMIT: 3GiB`** in the env of the two `vuls diff detection` steps (inherited by every vuls0 child process), and document the rationale in a new `Memory budget` section of the action description.

Measured effects (same rig as above):

| | worst-case collision (heavy-4 pool, 14 GiB cgroup) | full 150-task run |
|---|---|---|
| before | peak = limit, swap 2.3 GiB, 17,102 forced reclaims, PSI full 13.5% | peak 13.46 GiB (96% of budget), survived on luck |
| with `GOMEMLIMIT=3GiB` | peak 12.2 GiB, **zero** swap / reclaim / pressure | peak 13.0 GiB, zero swap / reclaim / pressure, wall +11% |

Per-task: the cap squeezes `sles15` from 5.9 → 3.6 GiB anon (2.6× its solo runtime — the GC-pressure cost lands only on the few tasks whose natural heap exceeds the limit; a `GOMEMLIMIT` sweep showed 3 GiB is the knee: 4 GiB leaves the worst-case sum at ~15 GiB, still over budget). `vuls diff db` is a single process with no collision risk and stays uncapped.

Longer-term follow-ups (out of scope here): a `--workers` flag in vuls2's diff commands for an extra safety margin, and structural reduction of vuls0's detect-path live heap (~3 GiB floor for sles15, which GOMEMLIMIT cannot go below).

## Verification

- YAML parses; `GOMEMLIMIT` present on exactly the two detection steps.
- Collision replay and full 150-task run under a 14 GiB cgroup v2 with the cap: rc=0, `memory.events` all zero, `memory.pressure` ≈ 0 (numbers above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)